### PR TITLE
Fix `getActiveTunnels`

### DIFF
--- a/lib/Saucelabs.js
+++ b/lib/Saucelabs.js
@@ -218,7 +218,7 @@ Saucelabs.prototype.getActiveTunnels = function(callback){
   var self = this;
 
   this.send({
-    path: 'tunnels',
+    path: self.options.username + '/tunnels',
     method: 'GET'
   }, function(err, res){
     if(err && typeof callback == 'function') return callback(err);


### PR DESCRIPTION
This method was always returning `That resource could not be found`, because the URL was missing the username.

Please push fixed version to npm ASAP. Thank you!
