### PR TITLE
Deprecate `getBrowsers` and replace it with `getAllBrowsers`, `getSeleniumBrowsers` and `getWebDriverBrowsers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ myAccount.getAccountDetails( function (err, res) {
     myAccount.getServiceStatus( function (err, res) {
 	//Status of the Sauce Labs services
 	console.log(res);
-	myAccount.getBrowsers( function (err, res) {
+	myAccount.getAllBrowsers( function (err, res) {
 	    //List of all browser/os combinations currently supported on Sauce Labs.
 	    console.log(res);
 	    myAccount.getJobs( function (err, res) {
@@ -144,10 +144,24 @@ myAccount.getAccountDetails( function (err, res) {
     </tr>
     <tr>
       <td>
-	GET /info/browsers <br />
+	GET /info/browsers/all <br />
 	Returns an array of strings corresponding to all the browsers currently supported on Sauce Labs. 
       </td>
-      <td>getBrowsers(cb) -> cb(err, res)</td>
+      <td>getAllBrowsers(cb) -> cb(err, res)</td>
+    </tr>
+    <tr>
+      <td>
+	GET /info/browsers/selenium-rc <br />
+	Returns an array of strings corresponding to all the browsers currently supported under Selenium on Sauce Labs. 
+      </td>
+      <td>getSeleniumBrowsers(cb) -> cb(err, res)</td>
+    </tr>
+    <tr>
+      <td>
+	GET /info/browsers/webdriver <br />
+	Returns an array of strings corresponding to all the browsers currently supported under WebDriver on Sauce Labs. 
+      </td>
+      <td>getWebDriverBrowsers(cb) -> cb(err, res)</td>
     </tr>
     <tr>
       <td>

--- a/lib/Saucelabs.js
+++ b/lib/Saucelabs.js
@@ -183,6 +183,48 @@ Saucelabs.prototype.getBrowsers = function(callback){
   })
 }
 
+Saucelabs.prototype.getAllBrowsers = function(callback){
+  var self = this;
+
+  this.send({
+    path: 'info/browsers/all',
+    method: 'GET'
+  }, function(err, res){
+    if(err && typeof callback == 'function') return callback(err);
+    if(typeof callback == 'function'){
+      callback(null, res);
+    }
+  })
+}
+
+Saucelabs.prototype.getSeleniumBrowsers = function(callback){
+  var self = this;
+
+  this.send({
+    path: 'info/browsers/selenium-rc',
+    method: 'GET'
+  }, function(err, res){
+    if(err && typeof callback == 'function') return callback(err);
+    if(typeof callback == 'function'){
+      callback(null, res);
+    }
+  })
+}
+
+Saucelabs.prototype.getWebDriverBrowsers = function(callback){
+  var self = this;
+
+  this.send({
+    path: 'info/browsers/webdriver',
+    method: 'GET'
+  }, function(err, res){
+    if(err && typeof callback == 'function') return callback(err);
+    if(typeof callback == 'function'){
+      callback(null, res);
+    }
+  })
+}
+
 Saucelabs.prototype.getTestCounter = function(callback){
   var self = this;
 


### PR DESCRIPTION
The official documentation (https://saucelabs.com/docs/rest) no longer uses http://saucelabs.com/rest/v1/info/browsers, but http://saucelabs.com/rest/v1/info/browsers/all, http://saucelabs.com/rest/v1/info/browsers/selenium-rc and http://saucelabs.com/rest/v1/info/browsers/webdriver to retrieve the list of browsers.

The biggest change I've noticed is that the old URL used the property `selenium_name`, while the new ones use `api_name`.

I haven't removed the `getBrowsers` method to keep backwards compatibility, but I've removed references to it in the _README_ to discourage use. I've also added `getAllBrowsers`, `getSeleniumBrowsers` and `getWebDriverBrowsers`.

What do you think?
