### PR TITLE
Fixed try catch block that caught errors in the callback handler for makeRequest

### DIFF
--- a/lib/SauceLabs.js
+++ b/lib/SauceLabs.js
@@ -269,14 +269,18 @@ function makeRequest(options, body, callback) {
       })
       .on('end', function () {
         try {
-          if (response.statusCode === 200) {
-            callback(null, JSON.parse(result));
-          } else {
-            callback(JSON.parse(result));
-          }
-        } catch (err) {
+          var res = JSON.parse(result);
+        } catch (e) {            
           callback('Could not parse response: ' + result);
+          return;
         }
+
+        if (response.statusCode === 200) {
+          callback(null, res);
+        } else {
+          callback(res);          
+        }
+        
       });
   });
 


### PR DESCRIPTION
Essentially if any error was thrown within the callback (or further down in the stack), it would be trapped by this callback and the error would never be output.

This caused a 4 hour debugging nightmare for me. Gross misuse of a try/catch block.
