### PR TITLE
Refactored getUserActivity and getAccountUsage to match API

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,6 @@ var sauce = new SauceLabs({
         Access current account activity.
       </td>
       <td>
-        getUserActivity(start, end, cb) -> cb(err, res) <br />
-        getUserActivity(start, cb) -> cb(err, res) <br />
         getUserActivity(cb) -> cb(err, res)
       </td>
     </tr>
@@ -130,6 +128,8 @@ var sauce = new SauceLabs({
         Access historical account usage data.
       </td>
       <td>
+        getAccountUsage(start, end, cb) -> cb(err, res) <br />
+        getAccountUsage(start, cb) -> cb(err, res) <br />
         getAccountUsage(cb) -> cb(err, res)
       </td>
     </tr>

--- a/lib/SauceLabs.js
+++ b/lib/SauceLabs.js
@@ -42,7 +42,21 @@ SauceLabs.prototype.getAccountLimits = function (callback) {
   }, callback);
 };
 
-SauceLabs.prototype.getUserActivity = function (start, end, callback) {
+SauceLabs.prototype.getUserActivity = function (callback) {
+  this.send({
+    method: 'GET',
+    path: ':username/activity'
+  }, callback);
+};
+
+SauceLabs.prototype.getUserConcurrency = function (callback) {
+  this.send({
+    method: 'GET',
+    path: 'users/:username/concurrency'
+  }, callback);
+};
+
+SauceLabs.prototype.getAccountUsage = function (start, end, callback) {
   if (typeof start === 'function') {
     callback = start;
     start    = null;
@@ -62,22 +76,8 @@ SauceLabs.prototype.getUserActivity = function (start, end, callback) {
 
   this.send({
     method: 'GET',
-    path: ':username/activity',
+    path: 'users/:username/usage',
     query: dates
-  }, callback);
-};
-
-SauceLabs.prototype.getUserConcurrency = function (callback) {
-  this.send({
-    method: 'GET',
-    path: 'users/:username/concurrency'
-  }, callback);
-};
-
-SauceLabs.prototype.getAccountUsage = function (callback) {
-  this.send({
-    method: 'GET',
-    path: 'users/:username/usage'
   }, callback);
 };
 

--- a/test/SauceLabs.js
+++ b/test/SauceLabs.js
@@ -59,39 +59,9 @@ describe('SauceLabs', function () {
     });
 
     describe('#getUserActivity', function () {
-      describe('without start and end dates', function () {
-        it('GETs `/rest/v1/:username/activity`', function (done) {
-          var mock = nockle.get('/rest/v1/:username/activity');
-          sauce.getUserActivity(verifySuccess(mock, done));
-        });
-      });
-
-      describe('with start date', function () {
-        var start = new Date('Jan 1, 1970 00:00:00');
-
-        it('GETs `/rest/v1/:username/activity?start=1970-01-01`', function (done) {
-          var mock = nockle.get('/rest/v1/:username/activity?start=1970-01-01');
-          sauce.getUserActivity(start, verifySuccess(mock, done));
-        });
-      });
-
-      describe('with end date', function () {
-        var end = new Date('Jan 1, 1971 00:00:00');
-
-        it('GETs `/rest/v1/:username/activity?end=1971-01-01`', function (done) {
-          var mock = nockle.get('/rest/v1/:username/activity?end=1971-01-01');
-          sauce.getUserActivity(null, end, verifySuccess(mock, done));
-        });
-      });
-
-      describe('with start and end dates', function () {
-        var start = new Date('Jan 1, 1970 00:00:00');
-        var end   = new Date('Jan 1, 1971 00:00:00');
-
-        it('GETs `/rest/v1/:username/activity?start=1970-01-01&end=1971-01-01`', function (done) {
-          var mock = nockle.get('/rest/v1/:username/activity?start=1970-01-01&end=1971-01-01');
-          sauce.getUserActivity(start, end, verifySuccess(mock, done));
-        });
+      it('GETs `/rest/v1/:username/activity`', function (done) {
+        var mock = nockle.get('/rest/v1/:username/activity');
+        sauce.getUserActivity(verifySuccess(mock, done));
       });
     });
 
@@ -103,9 +73,39 @@ describe('SauceLabs', function () {
     });
 
     describe('#getAccountUsage', function () {
-      it('GETs `/rest/v1/users/:username/usage`', function (done) {
-        var mock = nockle.get('/rest/v1/users/:username/usage');
-        sauce.getAccountUsage(verifySuccess(mock, done));
+      describe('without start and end dates', function () {
+        it('GETs `/rest/v1/users/:username/usage`', function (done) {
+          var mock = nockle.get('/rest/v1/users/:username/usage');
+          sauce.getAccountUsage(verifySuccess(mock, done));
+        });
+      });
+
+      describe('with start date', function () {
+        var start = new Date('Jan 1, 1970 00:00:00');
+
+        it('GETs `/rest/v1/users/:username/usage?start=1970-01-01`', function (done) {
+          var mock = nockle.get('/rest/v1/users/:username/usage?start=1970-01-01');
+          sauce.getAccountUsage(start, verifySuccess(mock, done));
+        });
+      });
+
+      describe('with end date', function () {
+        var end = new Date('Jan 1, 1971 00:00:00');
+
+        it('GETs `/rest/v1/users/:username/usage?end=1971-01-01`', function (done) {
+          var mock = nockle.get('/rest/v1/users/:username/usage?end=1971-01-01');
+          sauce.getAccountUsage(null, end, verifySuccess(mock, done));
+        });
+      });
+
+      describe('with start and end dates', function () {
+        var start = new Date('Jan 1, 1970 00:00:00');
+        var end = new Date('Jan 1, 1971 00:00:00');
+
+        it('GETs `/rest/v1/users/:username/usage?start=1970-01-01&end=1971-01-01`', function (done) {
+          var mock = nockle.get('/rest/v1/users/:username/usage?start=1970-01-01&end=1971-01-01');
+          sauce.getAccountUsage(start, end, verifySuccess(mock, done));
+        });
       });
     });
 


### PR DESCRIPTION
**Refactored `.getUserActivity`**
- Remove `start` and `end` parameters (the API endpoint doesn't have parameters)
- Update unit tests to reflect the change in function signature
- Update README with new usage of `.getUserActivity`

**Refactored `.getAccountUsage`**
- Add `start` and `end` parameters (the API allows these parameters)
- Update unit tests to reflect the change in function signature
- Update README with new usage of `.getGetAccountUsage`