### PR TITLE
Add Timeout to Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ var sauce = new SauceLabs({
 });
 ```
 
+## Changing the default timeout
+If a 60 second request timeout is not desired, you can define it in the constructor options. The timeout is specified in milliseconds. For example, to set a 30 second timeout you would add timeout: 30000 to the configuration.
+
+```javascript
+var sauce = new SauceLabs({
+  username: "your-sauce-username",
+  password: "your-sauce-api-key",
+  timeout: 30000
+});
+```
+
 
 ## Supported Methods
 

--- a/lib/SauceLabs.js
+++ b/lib/SauceLabs.js
@@ -16,7 +16,8 @@ var DEFAULTS = {
   proxy: null,
   hostname:  'saucelabs.com',
   base:      '/rest/v1/',
-  port:      '443'
+  port:      '443',
+  timeout: 60000 //ms
 };
 
 function SauceLabs(options) {
@@ -306,35 +307,40 @@ function makeRequest(options, body, callback) {
         options.agent = new HttpsProxyAgent(url.parse(options.proxy));
     }
     var request = https.request(options, function (response) {
-    var result = '';
-    if (callback) {
-      response
-        .on('data', function (chunk) {
-          result += chunk;
-        })
-        .on('end', function () {
-          var res;
+      var result = '';
+      if (callback) {
+        response
+          .on('data', function (chunk) {
+            result += chunk;
+          })
+          .on('end', function () {
+            var res;
 
-          try {
-            res = JSON.parse(result);
-          } catch (e) {
-            callback('Could not parse response: ' + result);
-            return;
-          }
+            try {
+              res = JSON.parse(result);
+            } catch (e) {
+              callback('Could not parse response: ' + result);
+              return;
+            }
 
-          if (response.statusCode === 200) {
-            callback(null, res);
-          } else {
-            callback(res);
-          }
-        });
-    }
+            if (response.statusCode === 200) {
+              callback(null, res);
+            } else {
+              callback(res);
+            }
+          });
+      }
   });
-
-  request
-    .on('error', function (err) {
-      callback('Could not send request: ' + err.message);
+  
+  if (options.timeout > 0) {
+    request.setTimeout(options.timeout, function () {
+      callback('Timeout sending request');
     });
+  }
+
+  request.on('error', function (err) {
+    callback('Could not send request: ' + err.message);
+  });
 
   if (body != null) {
     request.write(body);


### PR DESCRIPTION
By default, nodejs requests do not have a timeout set and will hang forever in the event of connection issues. This adds a configurable timeout, with a default of 60 seconds.

This resolves an issue I am seeing with the saucelabs reporter sometimes hanging in karma-sauce-launcher and making my builds get stuck.