### PR TITLE
Add create sub account endpoint

### DIFF
--- a/apis/sauce.json
+++ b/apis/sauce.json
@@ -1757,6 +1757,40 @@
         ]
       }
     },
+    "/v1/users/{username}/subaccounts": {
+      "get": {
+        "operationId": "get_subaccounts",
+        "parameters": [
+          {
+            "$ref": "#/parameters/username"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "404": {
+            "description": "User is not found",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        },
+        "summary": "User information",
+        "tags": [
+          "User"
+        ]
+      }
+    },
     "/v1/users/{username}/activity": {
       "get": {
         "operationId": "get_user_activity",


### PR DESCRIPTION
Seems this endpoint is missing. Tested it with:

```js
const SauceLabs = require('./build').default

const api = new SauceLabs()
api.getSubaccounts('cb-onboarding').then(
    (subaccounts) => console.log(subaccounts),
    (err) => console.error(err))
```
