### PR TITLE
Allow 204 responses

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -25,7 +25,7 @@ for (const { paths, parameters, host, basePath } of protocols) {
             }
 
             /**
-             * ensure we don't double registet commands
+             * ensure we don't double register commands
              */
             if (protocolFlattened.has(commandName)) {
                 throw new Error(`command ${commandName} already registered`)

--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,7 @@ export default class SauceLabs {
                 }
 
                 /* istanbul ignore if */
-                if (response.statusCode !== 200) {
+                if (response.statusCode !== 200 && response.statusCode !== 204) {
                     const reason = getErrorReason(body)
                     return reject(new Error(`Failed calling ${propName}, status code: ${response.statusCode}, reason: ${reason}`))
                 }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -96,6 +96,24 @@ test('should allow to make a request with body param via CLI call', async () => 
     expect(req.body).toEqual({ passed: false })
 })
 
+test('should update RDC job status with body param', async () =>  {
+    const api = new SauceLabs({})
+    await api.updateTest('89ec3cca-7092-41f1-8037-d035579fb8d1', { passed: true })
+
+    const req = request.mock.calls[0][0]
+    expect(req.method).toBe('PUT')
+    expect(req.body).toEqual({ passed: true })
+})
+
+test('should update RDC job status with body param via CLI call', async () =>  {
+    const api = new SauceLabs({})
+    await api.updateTest('89ec3cca-7092-41f1-8037-d035579fb8d1', '{ "passed": false }')
+
+    const req = request.mock.calls[0][0]
+    expect(req.method).toBe('PUT')
+    expect(req.body).toEqual({ passed: false })
+})
+
 test('should fail if param has wrong type', () => {
     const api = new SauceLabs({ user: 'foo', key: 'bar' })
     expect(() => api.listJobs(123, {


### PR DESCRIPTION
**Why is this change needed?**
The RDC updateTest command sends back a 204 response.
Even though we send the request and execute it properly, we through an error because the result is not 200 specifically.

**How does it address the issue?**
It checks if the response is 200 or 204 before failing.