### PR TITLE
docs(breaking-change): describe method mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,41 @@ import SauceLabs from 'saucelabs';
 })()
 ```
 
+## Breaking changes from v1 to v2
+
+Public APIs have changed from v1 to v2. Methods in v1 accepted a `callback` trailing parameter which is no more available with v2, instead all methods now return a Promise which can be `awaited` or `then`'d.
+
+Below, you can find the list of the mapped method names:
+
+| v1 | v2 |
+|----|----|
+| getAccountDetails(callback)   | async getUser(username) |
+| getAccountLimits(callback)   | ? |
+| getUserActivity(callback)   | async getUserActivity(username) |
+| getUserConcurrency(callback) | async getUserConcurrency(username) |
+| getAccountUsage(start, end, callback) | ? |
+| getJobs(callback) | async listJobs(username, { ...options }) // with option: full: true |
+| showJob(id, callback) | async getJob(username, id) |
+| showJobAssets(id, callback) | ? |
+| updateJob(id, data, callback) | async updateJob(username, id, body) |
+| stopJob(id, data, callback) | async stopJob(username, id) |
+| deleteJob(id, callback) | ? |
+| getActiveTunnels(callback) | async listAvailableTunnels(username) |
+| getTunnel(id, callback) | async getTunnel(username, id) |
+| deleteTunnel(id, callback) | async deleteTunnel(username, id) |
+| getServiceStatus(callback) |async getStatus() |
+| getBrowsers(callback) | ? |
+| getAllBrowsers(callback) | ? |
+| getSeleniumBrowsers(callback) | ? |
+| getWebDriverBrowsers(callback) | ? |
+| getTestCounter(callback) | ? |
+| updateSubAccount(data, callback) | ? |
+| deleteSubAccount(callback) | ? |
+| createSubAccount(data, callback) | ? |
+| createPublicLink(id, date, useHour, callback) | ? |
+| getSubAccountList(callback) | ? |
+| getSubAccounts(callback) | ? |
+
 ## Test
 
 To run the test suite, first invoke the following command within the repo, installing the development dependencies:


### PR DESCRIPTION
For consumers of the v1 of this library it's pretty annoying to find that there are massive breaking changes without any documentation or changelog. Furthermore several methods, including all browser related ones, are not available anymore, thus creating a show stopper for updating to the latest version.

Mapped methods with `?` haven't been found in [this list](https://github.com/saucelabs/node-saucelabs/blob/master/docs/interface.md) so are they maybe still existing under `/v1/...` but aren't described?