### PR TITLE
fix proxy functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "change-case": "^4.1.1",
     "got": "^10.6.0",
     "hash.js": "^1.1.7",
+    "tunnel": "0.0.6",
     "yargs": "^15.3.1"
   },
   "devDependencies": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -35,8 +35,8 @@ export const run = () => {
                 yargs.positional(param.name, paramDescription)
             }
         }, async (argv) => {
-            const { user, key, headless, region } = Object.assign({}, DEFAULT_OPTIONS, argv)
-            const api = new SauceLabs({ user, key, headless, region })
+            const { user, key, headless, region, proxy } = Object.assign({}, DEFAULT_OPTIONS, argv)
+            const api = new SauceLabs({ user, key, headless, region, proxy })
             const requiredParams = params.filter((p) => p.required).map((p) => argv[p.name])
 
             try {

--- a/src/constants.js
+++ b/src/constants.js
@@ -56,7 +56,8 @@ export const DEFAULT_OPTIONS = {
     user: process.env.SAUCE_USERNAME,
     key: process.env.SAUCE_ACCESS_KEY,
     headless: false,
-    region: 'us'
+    region: 'us',
+    proxy: process.env.HTTPS_PROXY || process.env.HTTP_PROXY
 }
 
 export const REGION_MAPPING = {
@@ -102,5 +103,6 @@ export const CLI_PARAMS = [{
 }, {
     alias: 'p',
     name: 'proxy',
-    description: 'use a proxy for fetching data instead of environment variables'
+    description: 'use a proxy for fetching data instead of environment variables',
+    default: DEFAULT_OPTIONS.proxy
 }]

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,8 @@ export default class SauceLabs {
             username: this.username,
             key: `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXX${(this._accessKey || '').slice(-6)}`,
             region: this._options.region,
-            headless: this._options.headless
+            headless: this._options.headless,
+            proxy: this._options.proxy
         }, { get: ::this.get })
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,11 @@
 import fs from 'fs'
 import path from 'path'
 import got from 'got'
-import tunnel from 'tunnel'
-import url from 'url'
 import { camelCase } from 'change-case'
 
 import {
     createHMAC, getSauceEndpoint, toString, getParameters,
-    isValidType, getStrictSsl
+    isValidType, createProxyAgent, getStrictSsl
 } from './utils'
 import {
     PROTOCOL_MAP, DEFAULT_OPTIONS, SYMBOL_INSPECT, SYMBOL_TOSTRING,
@@ -27,14 +25,9 @@ export default class SauceLabs {
         })
 
         if (this._options.proxy !== undefined) {
-            var proxyURL = url.parse(this._options.proxy)
+            var proxyAgent = createProxyAgent(this._options.proxy)
             this._api = got.extend({
-                agent: tunnel.httpsOverHttp({
-                    proxy: {
-                        host: proxyURL.hostname,
-                        port: proxyURL.port
-                    }
-                })
+                agent: proxyAgent
             }, this._api)
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import fs from 'fs'
 import path from 'path'
 import got from 'got'
+import tunnel from 'tunnel'
+import url from 'url'
 import { camelCase } from 'change-case'
 
 import {
@@ -21,9 +23,20 @@ export default class SauceLabs {
             username: this.username,
             password: this._accessKey,
             rejectUnauthorized: getStrictSsl(),
-            proxy: this._options.proxy,
-            followRedirect: true
+            followRedirect: true,
         })
+
+        if (this._options.proxy !== undefined) {
+            var proxyURL = url.parse(this._options.proxy)
+            this._api = got.extend({
+                agent: tunnel.httpsOverHttp({
+                    proxy: {
+                        host: proxyURL.hostname,
+                        port: proxyURL.port
+                    }
+                })
+            }, this._api)
+        }
 
         /**
          * public fields

--- a/src/utils.js
+++ b/src/utils.js
@@ -112,7 +112,6 @@ export function isValidType (option, expectedType) {
  */
 export function createProxyAgent (proxy) {
     var proxyURL = url.parse(proxy)
-
     if (proxyURL.protocol === 'https:') {
         return tunnel.httpsOverHttps({
             proxy: {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,6 @@
 import crypto from 'crypto'
+import tunnel from 'tunnel'
+import url from 'url'
 
 import { REGION_MAPPING, TO_STRING_TAG, PARAMETERS_MAP } from './constants'
 
@@ -101,6 +103,35 @@ export function isValidType (option, expectedType) {
         return Array.isArray(option)
     }
     return typeof option === expectedType
+}
+
+/**
+ * get a tunnel Agent for proxy tunneling
+ * @param  {string}  proxy  proxy URL that traffic will be tunneled with
+ * @return {Agent} proxy Agent object
+ */
+export function createProxyAgent (proxy) {
+    var proxyURL = url.parse(proxy)
+
+    if (proxyURL.protocol === 'https:') {
+        return tunnel.httpsOverHttps({
+            proxy: {
+                host: proxyURL.hostname,
+                port: proxyURL.port
+            }
+        })
+    } else if (proxyURL.protocol === 'http:') {
+        return tunnel.httpsOverHttp({
+            proxy: {
+                host: proxyURL.hostname,
+                port: proxyURL.port
+            }
+        })
+    } else {
+        throw new Error('Only http and https protocols are supported for proxying traffic.'
+                        + `\nWe got ${proxyURL.protocol}`)
+    }
+
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -66,7 +66,8 @@ export function toString (scope) {
   username: '${scope.username}',
   key: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXX${scope._accessKey.slice(-6)}',
   region: '${scope._options.region}',
-  headless: ${scope._options.headless}
+  headless: ${scope._options.headless},
+  proxy: ${scope._options.proxy}
 }`
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -127,11 +127,10 @@ export function createProxyAgent (proxy) {
                 port: proxyURL.port
             }
         })
-    } else {
-        throw new Error('Only http and https protocols are supported for proxying traffic.'
-                        + `\nWe got ${proxyURL.protocol}`)
     }
 
+    throw new Error('Only http and https protocols are supported for proxying traffic.'
+                        + `\nWe got ${proxyURL.protocol}`)
 }
 
 /**

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -189,7 +189,6 @@ test('should support proxy options', async () => {
     const requestOptions = got.extend.mock.calls[1][0]
 
     await expect(requestOptions.agent).toBeDefined()
-    // await expect(requestOptions.agent).toEqual(proxy)
 })
 
 test('should put asset into file as binary', async () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -53,7 +53,7 @@ test('should grab proxy from env variable', () => {
     const SauceLabsNew = require('../src').default
     const api = new SauceLabsNew()
     expect(util.inspect(api))
-        .toContain('proxy: \'http://my.proxy.com:8080\'')
+        .toMatch(/proxy: '??http:\/\/my\.proxy\.com:8080/) //
 })
 
 test('should throw if API command is unknown', () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -183,13 +183,13 @@ test('should fail if parameters are not given properly', async () => {
 })
 
 test('should support proxy options', async () => {
-    const proxy = 'https://my.proxy.com'
+    const proxy = 'http://my.proxy.com:8080'
     const api = new SauceLabs({ user: 'foo', key: 'bar', proxy })
     await api.downloadJobAsset('some-id', 'performance.json')
-    const requestOptions = got.extend.mock.calls[0][0]
+    const requestOptions = got.extend.mock.calls[1][0]
 
-    await expect(requestOptions.proxy).toBeDefined()
-    await expect(requestOptions.proxy).toEqual(proxy)
+    await expect(requestOptions.agent).toBeDefined()
+    // await expect(requestOptions.agent).toEqual(proxy)
 })
 
 test('should put asset into file as binary', async () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -47,13 +47,23 @@ test('should grab username and access key from env variable', () => {
         .toContain('key: \'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXfoobar\'')
 })
 
-test('should grab proxy from env variable', () => {
+test('should grab http proxy from env variable', () => {
     jest.resetModules()
     process.env.HTTP_PROXY = 'http://my.proxy.com:8080'
     const SauceLabsNew = require('../src').default
     const api = new SauceLabsNew()
     expect(util.inspect(api))
-        .toMatch(/proxy: '??http:\/\/my\.proxy\.com:8080/) //
+        .toMatch(/proxy: '??http:\/\/my\.proxy\.com:8080/)
+    delete process.env.HTTP_PROXY
+})
+
+test('should grab https proxy from env variable', () => {
+    jest.resetModules()
+    process.env.HTTPS_PROXY = 'https://my.proxy.com:443'
+    const SauceLabsNew = require('../src').default
+    const api = new SauceLabsNew()
+    expect(util.inspect(api))
+        .toMatch(/proxy: '??https:\/\/my\.proxy\.com:443/)
 })
 
 test('should throw if API command is unknown', () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -12,7 +12,8 @@ test('should be inspectable', () => {
   username: 'foo',
   key: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXbar',
   region: 'us',
-  headless: false
+  headless: false,
+  proxy: undefined
 }`)
 })
 
@@ -44,6 +45,15 @@ test('should grab username and access key from env variable', () => {
         .toContain('username: \'barfoo\'')
     expect(util.inspect(api))
         .toContain('key: \'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXfoobar\'')
+})
+
+test('should grab proxy from env variable', () => {
+    jest.resetModules()
+    process.env.HTTP_PROXY = 'http://my.proxy.com:8080'
+    const SauceLabsNew = require('../src').default
+    const api = new SauceLabsNew()
+    expect(util.inspect(api))
+        .toContain('proxy: \'http://my.proxy.com:8080\'')
 })
 
 test('should throw if API command is unknown', () => {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,4 +1,6 @@
-import { createHMAC, getSauceEndpoint, toString, isValidType, getStrictSsl } from '../src/utils'
+import { createHMAC, getSauceEndpoint, toString, isValidType, createProxyAgent, getStrictSsl } from '../src/utils'
+import http from 'http'
+import https from 'https'
 
 test('createHMAC', async () => {
     expect(await createHMAC('foo', 'bar', 'loo123'))
@@ -51,6 +53,28 @@ test('isValidType', () => {
     expect(isValidType(null, 'array')).toBe(false)
 })
 
+describe('createProxyAgent', ()=> {
+    expect(createProxyAgent('http://my.proxy.com:8080'))
+        .toEqual(expect.objectContaining({
+            proxyOptions: {
+                host: 'my.proxy.com',
+                port: '8080'
+            },
+            request: http.request
+        }))
+    expect(createProxyAgent('https://my.proxy.com:443'))
+        .toEqual(expect.objectContaining({
+            proxyOptions: {
+                host: 'my.proxy.com',
+                port: '443'
+            },
+            request: https.request
+        }))
+    expect(() => {
+        createProxyAgent('ftp://my.proxy.com:21')
+    }).toThrowError(/Only http and https protocols are supported for proxying traffic./)
+
+})
 describe('getStrictSsl', () => {
     beforeEach(function() {
         delete process.env.STRICT_SSL

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -41,7 +41,8 @@ test('toString', () => {
   username: 'foobar',
   key: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXX2b17b0',
   region: 'us',
-  headless: false
+  headless: false,
+  proxy: undefined
 }`)
 })
 

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -76,6 +76,7 @@ describe('createProxyAgent', ()=> {
     }).toThrowError(/Only http and https protocols are supported for proxying traffic./)
 
 })
+
 describe('getStrictSsl', () => {
     beforeEach(function() {
         delete process.env.STRICT_SSL


### PR DESCRIPTION
**Summary**
This PR, when finished would fix the proxy option and not rely on HTTP_PROXY as that was used by request and not got.

This fix will allow you to do something like:
```bash
sl -p http://my.proxy.com:8080 getCurrentUserFull
```
as well as something like this via Node:
```node
const api = new SauceLabs({ user: 'foo', key: 'bar', proxy: 'http://my.proxy.com:8080' })
```

**Details**

Currently the proxy option was being added to the got constructor under as 'proxy'
see:
https://github.com/saucelabs/node-saucelabs/blob/9e7bc659d0d9e8f2b80b326ef75be07929736727/src/index.js#L24

problem with this is that got does not have an option proxy and per their docs ([link](https://github.com/sindresorhus/got/blob/master/readme.md#proxies)) this needs to be passed as an agent with the `tunnel` package (or any Agent from what I can see)

**Changes Done**
- Added tunnel package
- Fixed CLI to actually pass the proxy flag to the SauceLabs constructor
- Create a httpsOverHttp tunnel since this package only sends https requests and almost all proxies I've encountered at Sauce are over http

**Help requested**

There's still a test that I commented out that I need to get working before this is done.
Before I do that I want some input if this is the way to go about this.
I don't love using the tunnel package since it seems like it hasn't had a publish in two years and it adds another dependency that people not using proxies wouldn't need.

There will be something similar to be done on the webdriverio project since this:
https://webdriver.io/docs/proxy.html#proxy-between-driver-and-test
is now outdated with the release of v6 with got (I can make a PR for that too once we land on what we want to do)

