### PR TITLE
Allow specifying a Sauce Connect version

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ $ sl downloadJobAsset 690c5877710c422d8be4c622b40c747f video.mp4 --filepath ./vi
 or start Sauce Connect Proxy in EU datacenter:
 
 ```sh
+# start Sauce Connect tunnel for eu-central-1 region
 $ sl sc --region eu --tunnel-identifier "my-tunnel"
-
+# run a specific Sauce Connect version
+$ sl sc --scVersion 4.5.4
 # see all available Sauce Connect parameters via:
 $ sl sc --help
 ```

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "codecov": "^3.7.0",
     "eslint": "^6.8.0",
     "eslint-plugin-import": "^2.20.2",
-    "jest": "^26.0.1",
+    "jest": "^25.5.4",
     "np": "^6.2.3",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,15 +1,15 @@
 import { camelCase } from 'change-case'
 import { version } from '../package.json'
 
-export const SAUCE_CONNECT_VERSION = '4.5.4'
+export const DEFAULT_SAUCE_CONNECT_VERSION = '4.5.4'
 export const SAUCE_CONNECT_BASE = 'https://saucelabs.com/downloads'
 export const SAUCE_CONNECT_DISTS = [
-    [`${SAUCE_CONNECT_BASE}/sc-${SAUCE_CONNECT_VERSION}-osx.zip`, 'darwin'],
-    [`${SAUCE_CONNECT_BASE}/sc-${SAUCE_CONNECT_VERSION}-win32.zip`, 'win32'],
-    [`${SAUCE_CONNECT_BASE}/sc-${SAUCE_CONNECT_VERSION}-linux.tar.gz`, 'linux', 'x64'],
-    [`${SAUCE_CONNECT_BASE}/sc-${SAUCE_CONNECT_VERSION}_linux32.tar.gz`, 'linux']
+    [`${SAUCE_CONNECT_BASE}/sc-%s-osx.zip`, 'darwin'],
+    [`${SAUCE_CONNECT_BASE}/sc-%s-win32.zip`, 'win32'],
+    [`${SAUCE_CONNECT_BASE}/sc-%s-linux.tar.gz`, 'linux', 'x64'],
+    [`${SAUCE_CONNECT_BASE}/sc-%s_linux32.tar.gz`, 'linux']
 ]
-export const SAUCE_VERSION_NOTE = `node-saucelabs v${version}\nSauce Connect v${SAUCE_CONNECT_VERSION}`
+export const SAUCE_VERSION_NOTE = `node-saucelabs v${version}\nSauce Connect v${DEFAULT_SAUCE_CONNECT_VERSION}`
 
 const protocols = [
     require('../apis/sauce.json'),
@@ -121,6 +121,16 @@ const CLI_PARAM_KEYS = CLI_PARAMS.map((param) => param.name)
 const CLI_PARAM_ALIASES = CLI_PARAMS.map((param) => param.alias).filter(Boolean)
 
 export const SAUCE_CONNECT_CLI_PARAMS = [{
+    /**
+     * custom parameter
+     */
+    name: 'sc-version',
+    description: 'Specify the Sauce Connect version you want to use.',
+    default: DEFAULT_SAUCE_CONNECT_VERSION
+}, {
+    /**
+     * Sauce Connect parameter
+     */
     alias: 'a',
     name: 'auth',
     description: 'Perform basic authentication when an URL on <host:port> asks for a username and password.'

--- a/tests/__mocks__/bin-wrapper.js
+++ b/tests/__mocks__/bin-wrapper.js
@@ -1,3 +1,4 @@
+const instances = []
 class BinWrapperMock {
     constructor () {
         this.run = jest.fn().mockReturnValue(Promise.resolve()),
@@ -6,7 +7,9 @@ class BinWrapperMock {
         this.dest = jest.fn().mockReturnValue(this)
         this.use = jest.fn().mockReturnValue(this)
         this.version = jest.fn().mockReturnValue(this)
+        instances.push(this)
     }
 }
 
 export default BinWrapperMock
+export { instances }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -3,6 +3,7 @@ import got from 'got'
 import { spawn } from 'child_process'
 
 import SauceLabs from '../src'
+import { instances } from 'bin-wrapper'
 
 jest.mock('fs')
 const fs = require('fs')
@@ -251,9 +252,17 @@ describe('startSauceConnect', () => {
     it('should start sauce connect with proper parsed args', async () => {
         const api = new SauceLabs({ user: 'foo', key: 'bar', headless: true })
         setTimeout(() => stdoutEmitter.emit('data', 'Sauce Connect is up, you may start your tests'), 50)
-        await api.startSauceConnect({ tunnelIdentifier: 'my-tunnel', 'proxy-tunnel': 'abc' })
+        await api.startSauceConnect({
+            scVersion: '1.2.3',
+            tunnelIdentifier: 'my-tunnel',
+            'proxy-tunnel': 'abc'
+        })
         expect(spawn).toBeCalledTimes(1)
         expect(spawn.mock.calls).toMatchSnapshot()
+
+        expect(instances).toHaveLength(1)
+        expect(instances[0].dest.mock.calls[0][0].endsWith('.sc-v1.2.3'))
+            .toBe(true)
     })
 
     it('should close sauce connect', async () => {

--- a/tests/typings/test.ts
+++ b/tests/typings/test.ts
@@ -12,7 +12,10 @@ async function foobar () {
     const job = await api.getJobV1_1('foobar')
     console.log(job.selenium_version)
 
-    const sc = await api.startSauceConnect({ tunnelIdentifier: '1234' })
+    const sc = await api.startSauceConnect({
+        scVersion: '4.5.4',
+        tunnelIdentifier: '1234'
+    })
     sc.cp.pid
     await sc.close()
 


### PR DESCRIPTION
It would be nice if someone could easily switch multiple Sauce Connect versions by passing in a parameter. It could also allow Sauce employees and their customers to test new beta versions.