### PR TITLE
Add testrunner API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ or download a job asset:
 $ sl downloadJobAsset 690c5877710c422d8be4c622b40c747f video.mp4 --filepath ./video.mp4
 ```
 
+or upload a job asset:
+
+```sh
+$ sl uploadJobAssets 690c5877710c422d8be4c622b40c747f --files ./video.mp4 --files ./log.json
+```
+
 or start Sauce Connect Proxy in EU datacenter:
 
 ```sh
@@ -123,12 +129,12 @@ import SauceLabs from 'saucelabs';
     // const myAccount = new SauceLabs({ user: "YOUR-USER", key: "YOUR-ACCESS-KEY"});
 
     // get job details of last run job
-    const job = await myAccount.listJobs(
+    const jobs = await myAccount.listJobs(
         process.env.SAUCE_USERNAME,
         { limit: 1, full: true }
     );
 
-    console.log(job);
+    console.log(jobs);
     /**
      * outputs:
      * { jobs:
@@ -181,8 +187,16 @@ import SauceLabs from 'saucelabs';
     })
 
     // run a test
+    // ...
 
+    // close Sauce Connect
     await sc.close()
+
+    // upload additional log files and attach it to your Sauce job
+    await myAccount.uploadJobAssets(
+        '76e693dbe6ff4910abb0bc3d752a971e',
+        ['video.mp4', 'log.json']
+    )
 })()
 ```
 

--- a/apis/performance.json
+++ b/apis/performance.json
@@ -5,7 +5,31 @@
     "version":"0.247.0",
     "description":"Performance API provides essential information about performance of tested web application."
   },
-  "host":"api.us-west-1.saucelabs.com",
+  "host":"saucelabs.com",
+  "servers":[
+    {
+      "url":"https://api.{region}.saucelabs.{tld}",
+      "variables":{
+        "region":{
+          "default":"us-west-1",
+          "description":"region of datacenter",
+          "enum":[
+            "us-west-1",
+            "eu-central-1",
+            "staging"
+          ]
+        },
+        "tld":{
+          "default":"com",
+          "description":"internal or external API",
+          "enum":[
+            "net",
+            "com"
+          ]
+        }
+      }
+    }
+  ],
   "basePath":"/v2/performance",
   "schemes":[
     "https"

--- a/apis/rdc.json
+++ b/apis/rdc.json
@@ -5,6 +5,12 @@
     "version":"1.0.0",
     "title":"API Reference"
   },
+  "servers":[
+    {
+      "url":"https://app.testobject.com",
+      "variables":{}
+    }
+  ],
   "host":"app.testobject.com",
   "basePath":"/api/rest",
   "tags":[

--- a/apis/sauce.json
+++ b/apis/sauce.json
@@ -1,5 +1,60 @@
 {
+  "swagger":"2.0",
+  "info":{
+    "contact":{
+      "email":"support@saucelabs.com",
+      "name":"API Support",
+      "url":"https://saucelabs.com/support"
+    },
+    "description":"This is a REST API documentation provided by Sauce Labs",
+    "license":{
+      "name":"Apache 2.0",
+      "url":"http://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "termsOfService":"https://saucelabs.com/terms-of-service",
+    "title":"Sauce Labs REST API",
+    "version":"0.0.1"
+  },
+  "host":"saucelabs.com",
   "basePath":"/rest",
+  "servers":[
+    {
+      "url":"https://api.{region}.saucelabs.{tld}",
+      "variables":{
+        "region":{
+          "default":"us-west-1",
+          "description":"region of datacenter",
+          "enum":[
+            "us-west-1",
+            "us-east-1",
+            "eu-central-1",
+            "staging"
+          ]
+        },
+        "tld":{
+          "default":"com",
+          "description":"internal or external API",
+          "enum":[
+            "net",
+            "com"
+          ]
+        }
+      }
+    }
+  ],
+  "schemes":[
+    "https"
+  ],
+  "securityDefinitions":{
+    "BasicAuth":{
+      "type":"basic"
+    },
+    "PrivApiKey":{
+      "in":"header",
+      "name":"Signature",
+      "type":"apiKey"
+    }
+  },
   "definitions":{
     "Activity":{
       "properties":{
@@ -717,35 +772,12 @@
       "type":"object"
     }
   },
-  "host":"saucelabs.com",
-  "info":{
-    "contact":{
-      "email":"support@saucelabs.com",
-      "name":"API Support",
-      "url":"https://saucelabs.com/support"
-    },
-    "description":"This is a REST API documentation provided by Sauce Labs",
-    "license":{
-      "name":"Apache 2.0",
-      "url":"http://www.apache.org/licenses/LICENSE-2.0.html"
-    },
-    "termsOfService":"https://saucelabs.com/terms-of-service",
-    "title":"Sauce Labs REST API",
-    "version":"0.0.1"
-  },
   "parameters":{
-    "assetName":{
-      "description":"filename of the asset",
+    "filename":{
+      "description":"filename",
       "in":"path",
-      "name":"assetName",
+      "name":"filename",
       "required":true,
-      "type":"string"
-    },
-    "filepath":{
-      "description":"file path to store the asset at",
-      "in":"path",
-      "name":"filepath",
-      "required":false,
       "type":"string"
     },
     "full":{
@@ -2297,10 +2329,7 @@
             "$ref":"#/parameters/id"
           },
           {
-            "$ref":"#/parameters/assetName"
-          },
-          {
-            "$ref":"#/parameters/filepath"
+            "$ref":"#/parameters/filename"
           }
         ],
         "responses":{
@@ -2329,26 +2358,5 @@
         ]
       }
     }
-  },
-  "schemes":[
-    "https"
-  ],
-  "security":[
-    {
-      "BasicAuth":[
-
-      ]
-    }
-  ],
-  "securityDefinitions":{
-    "BasicAuth":{
-      "type":"basic"
-    },
-    "PrivApiKey":{
-      "in":"header",
-      "name":"Signature",
-      "type":"apiKey"
-    }
-  },
-  "swagger":"2.0"
+  }
 }

--- a/apis/sauce.json
+++ b/apis/sauce.json
@@ -773,6 +773,20 @@
     }
   },
   "parameters":{
+    "assetName": {
+      "description": "filename of the asset",
+      "in": "path",
+      "name": "assetName",
+      "required": true,
+      "type": "string"
+    },
+    "filepath": {
+      "description": "file path to store the asset at",
+      "in": "path",
+      "name": "filepath",
+      "required": false,
+      "type": "string"
+    },
     "filename":{
       "description":"filename",
       "in":"path",
@@ -2330,6 +2344,9 @@
           },
           {
             "$ref":"#/parameters/filename"
+          },
+          {
+            "$ref": "#/parameters/filepath"
           }
         ],
         "responses":{

--- a/apis/testrunner.json
+++ b/apis/testrunner.json
@@ -122,17 +122,5 @@
         }
       }
     }
-  },
-  "security":[
-    {
-      "basicAuth":[
-
-      ]
-    },
-    {
-      "bearerAuth":[
-
-      ]
-    }
-  ]
+  }
 }

--- a/apis/testrunner.json
+++ b/apis/testrunner.json
@@ -46,6 +46,24 @@
       "description":"Log files that were captured while the test was running."
     }
   ],
+  "parameters": {
+    "jobId": {
+      "in":"path",
+      "name":"jobId",
+      "required":true,
+      "description":"id of the job that was run on Sauce Labs",
+      "schema":{
+        "type":"string"
+      }
+    },
+    "files": {
+      "description": "s path to upload and attach to your job",
+      "in": "path",
+      "name": "files",
+      "required": false,
+      "type": "string"
+    }
+  },
   "components":{
     "securitySchemes":{
       "bearerAuth":{
@@ -73,13 +91,10 @@
         ],
         "parameters":[
           {
-            "in":"path",
-            "name":"jobId",
-            "required":true,
-            "description":"id of the job that was run on Sauce Labs",
-            "schema":{
-              "type":"string"
-            }
+            "$ref": "#/parameters/jobId"
+          },
+          {
+            "$ref": "#/parameters/files"
           }
         ],
         "requestBody":{

--- a/apis/testrunner.json
+++ b/apis/testrunner.json
@@ -1,0 +1,138 @@
+{
+  "openapi":"3.0.0",
+  "info":{
+    "description":"A service that orchestrates the Sauce cloud as well as test runner packages.",
+    "version":"0.1.7",
+    "title":"Testrunner Orchestrator",
+    "termsOfService":"https://saucelabs.com/terms-of-service",
+    "contact":{
+      "name":"Open Source Program Office at Sauce",
+      "email":"opensource@saucelabs.com",
+      "url":"https://saucelabs.com"
+    }
+  },
+  "externalDocs":{
+    "description":"Sauce Labs Wiki",
+    "url":"https://wiki.saucelabs.com"
+  },
+  "basePath": "/v1/testrunner",
+  "servers":[
+    {
+      "url":"https://api.{region}.saucelabs.{tld}",
+      "variables":{
+        "region":{
+          "default":"us-west-1",
+          "description":"region of datacenter",
+          "enum":[
+            "us-west-1",
+            "eu-central-1",
+            "staging"
+          ]
+        },
+        "tld":{
+          "default":"com",
+          "description":"internal or external API",
+          "enum":[
+            "net",
+            "com"
+          ]
+        }
+      }
+    }
+  ],
+  "tags":[
+    {
+      "name":"Log Files",
+      "description":"Log files that were captured while the test was running."
+    }
+  ],
+  "components":{
+    "securitySchemes":{
+      "bearerAuth":{
+        "type":"http",
+        "scheme":"bearer",
+        "bearerFormat":"JWT"
+      },
+      "basicAuth":{
+        "type":"http",
+        "scheme":"basic"
+      }
+    }
+  },
+  "paths":{
+    "/jobs/{jobId}/assets":{
+      "put":{
+        "operationId":"uploadJobAssets",
+        "summary":"Upload job assets",
+        "externalDocs":{
+          "description":"TBD",
+          "url":"https://wiki.saucelabs.com"
+        },
+        "tags":[
+          "Job"
+        ],
+        "parameters":[
+          {
+            "in":"path",
+            "name":"jobId",
+            "required":true,
+            "description":"id of the job that was run on Sauce Labs",
+            "schema":{
+              "type":"string"
+            }
+          }
+        ],
+        "requestBody":{
+          "content":{
+            "multipart/form-data":{
+              "schema":{
+                "type":"object",
+                "properties":{
+                  "file":{
+                    "type":"array",
+                    "items":{
+                      "type":"string",
+                      "format":"binary"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses":{
+          "200":{
+            "description":"Object containing list of uploaded files.",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "type":"array",
+                  "items":{
+                    "type":"string",
+                    "description":"uploaded file name"
+                  },
+                  "example":[
+                    "log.json",
+                    "video.mp4"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "security":[
+    {
+      "basicAuth":[
+
+      ]
+    },
+    {
+      "bearerAuth":[
+
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "bin-wrapper": "^4.1.0",
     "change-case": "^4.1.1",
+    "form-data": "^3.0.0",
     "got": "^11.1.4",
     "hash.js": "^1.1.7",
     "tunnel": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -84,8 +84,8 @@
       "global": {
         "branches": 93,
         "functions": 100,
-        "lines": 97,
-        "statements": 97
+        "lines": 98,
+        "statements": 98
       }
     },
     "testEnvironment": "node"

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,7 +1,5 @@
-const { REGION_MAPPING, SAUCE_CONNECT_CLI_PARAMS } = require('../src/constants')
-const regions = Object.keys(REGION_MAPPING)
-    .map(key => `"${key}"`)
-    .join(' | ')
+const { SAUCE_CONNECT_CLI_PARAMS, ASSET_REGION_MAPPING } = require('../src/constants')
+const regions = Object.keys(ASSET_REGION_MAPPING).map(key => `"${key}"`).join(' | ')
 
 exports.TS_IMPORTS = `
 import { ChildProcess } from 'child_process';

--- a/scripts/generate-typings.js
+++ b/scripts/generate-typings.js
@@ -11,6 +11,14 @@ const {
 
 function generateTypingsForApi(file) {
     const swagger = JSON.parse(fs.readFileSync(file, 'UTF-8'))
+
+    if (swagger.swagger !== '2.0') {
+        return console.log(
+            `Specification for ${file} has not the Swagger v2 format.\n` +
+            'TypeScript generation currently is only supported for Swagger v2.0.'
+        )
+    }
+
     const definitions = CodeGen.getTypescriptCode({
         className: 'SauceLabs',
         swagger,
@@ -56,12 +64,13 @@ fs.readdir(path.join(__dirname, '../apis'), (err, files) => {
     let result = `${TS_IMPORTS}\n${TS_SAUCELABS_OBJ}\n${TC_SAUCE_CONNECT_CLASS}\n${TC_SAUCE_CONNECT_OBJ}`
     const methods = [
         TC_START_SC,
-        ...files.map((api) => {
-            const typings = generateTypingsForApi('./apis/' + api)
-            result += `\n\n ${typings.defintions}`
-
-            return typings.methods
-        })
+        ...files
+            .map((api) => generateTypingsForApi('./apis/' + api))
+            .filter(Boolean)
+            .map((typings) => {
+                result += `\n\n ${typings.defintions}`
+                return typings.methods
+            })
     ].join('\n\n')
 
     result += `\n\ndeclare class SauceLabs {\n

--- a/src/cli.js
+++ b/src/cli.js
@@ -56,7 +56,12 @@ export const run = () => {
                 return process.exit(1)
             }
 
-            return api
+            /**
+             * only return for testing purposes
+             */
+            if (process.env.JEST_WORKER_ID) {
+                return api
+            }
         })
     }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,12 +14,13 @@ export const SAUCE_VERSION_NOTE = `node-saucelabs v${version}\nSauce Connect v${
 const protocols = [
     require('../apis/sauce.json'),
     require('../apis/rdc.json'),
-    require('../apis/performance.json')
+    require('../apis/performance.json'),
+    require('../apis/testrunner.json')
 ]
 
 const protocolFlattened = new Map()
 const parametersFlattened = new Map()
-for (const { paths, parameters, host, basePath } of protocols) {
+for (const { paths, parameters, basePath, servers } of protocols) {
     for (const [name, description] of Object.entries(parameters || {})) {
         parametersFlattened.set(name, description)
     }
@@ -45,7 +46,7 @@ for (const { paths, parameters, host, basePath } of protocols) {
 
             protocolFlattened.set(
                 commandName,
-                { method, endpoint, description, host, basePath }
+                { method, endpoint, description, servers, basePath }
             )
         }
     }
@@ -71,17 +72,20 @@ export const DEFAULT_OPTIONS = {
     proxy: process.env.HTTPS_PROXY || process.env.HTTP_PROXY
 }
 
-export const REGION_MAPPING = {
-    'us': 'us-west-1.', // default endpoint
+export const ASSET_REGION_MAPPING = {
+    'us': '',
     'eu': 'eu-central-1.',
-    'us-west-1': 'us-west-1.',
-    'eu-central-1': 'eu-central-1.'
+    'us-west-1': '',
+    'us-east-1': 'us-east-1.',
+    'eu-central-1': 'eu-central-1.',
+    'staging': 'staging.'
 }
 
 export const SYMBOL_INSPECT = Symbol.for('nodejs.util.inspect.custom')
 export const SYMBOL_TOSTRING = Symbol.toStringTag
 export const SYMBOL_ITERATOR = Symbol.iterator
 export const TO_STRING_TAG = 'SauceLabs API Client'
+export const DEFAULT_PROTOCOL = 'https://'
 
 export const USAGE = `Sauce Labs API CLI
 

--- a/src/index.js
+++ b/src/index.js
@@ -329,12 +329,16 @@ export default class SauceLabs {
         }
     }
 
-    async _uploadJobAssets (jobId, filePaths) {
+    async _uploadJobAssets (jobId, { files = [] } = {}) {
+        if (files.length === 0) {
+            throw new Error('No files to upload selected')
+        }
+
         const { servers, basePath, method, endpoint } = PROTOCOL_MAP.get('uploadJobAssets')
         const uri = getAPIHost(servers, basePath, this._options) + endpoint.replace('{jobId}', jobId)
         const body = new FormData()
 
-        for (const filePath of filePaths) {
+        for (const filePath of files) {
             const readStream = fs.createReadStream(filePath.startsWith('/')
                 ? filePath
                 : path.join(process.cwd(), filePath)
@@ -343,7 +347,7 @@ export default class SauceLabs {
         }
 
         try {
-            const res = await this._api.get(uri, { method, body })
+            const res = await this._api(uri, { method, body })
 
             /**
              * parse asset as json if proper content type is given

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,9 @@
 import crypto from 'crypto'
 import tunnel from 'tunnel'
 import url from 'url'
+import path from 'path'
 
-import { REGION_MAPPING, TO_STRING_TAG, PARAMETERS_MAP } from './constants'
+import { ASSET_REGION_MAPPING, TO_STRING_TAG, PARAMETERS_MAP, DEFAULT_PROTOCOL } from './constants'
 
 /**
  * Create HMAC token to receive job assets
@@ -33,27 +34,58 @@ export function createHMAC (username, key, jobId) {
  * @param  {string}  protocol  protcol to be used
  * @return {string}            endpoint base url (e.g. `https://us-east1.headless.saucelabs.com`)
  */
-export function getSauceEndpoint (hostname, region, headless, protocol = 'https://') {
-    const dcRegion = REGION_MAPPING[region] ? region : 'us'
-    let locale = headless ? 'us-east-1.' : REGION_MAPPING[dcRegion]
-    let subdomain = ''
+export function getAPIHost (servers, basePath, options) {
+    /**
+     * allows to set an arbitrary host (for internal use only)
+     */
+    const apiUrl = options.host || servers[0].url
+    let host = DEFAULT_PROTOCOL + path.join(apiUrl.replace(DEFAULT_PROTOCOL, ''), basePath)
 
     /**
-     * check if endpoint base has subdomain
-     * e.g. api.saucelabs.com
+     * allow short region handles to stay backwards compatible
+     * ToDo(Christian): consider to remove when making a breaking update
      */
-    if (!headless && hostname.split('.').length > 2) {
-        subdomain = hostname.split('.')[0] + '.'
-        hostname = hostname.split('.').slice(-2).join('.')
-        // RDC only has 1 endpoint for both DC's, so if the url contains `testobject` clear the `locale`
-        locale = hostname.includes('testobject') ? '' : locale
-    } else if (!headless && region === 'us') {
-        locale = ''
-    } else if (locale === 'us-west-1.') { // us-west-1 is currently not a valid endpoint for Sauce
-        locale = ''
+    if (options.region) {
+        if (options.region === 'us') options.region = 'us-west-1'
+        if (options.region === 'eu') options.region = 'eu-central-1'
+        if (options.headless) options.region = 'us-east-1'
     }
 
-    return protocol + subdomain + locale + hostname
+    for (const [option, value] of Object.entries(servers[0].variables)) {
+        const hostOption = options[option] || value.default
+
+        /**
+         * check if option is valid
+         */
+        if (!value.enum.includes(hostOption)) {
+            throw new Error(`Option "${option}" contains invalid value ("${hostOption}"), allowed are: ${value.enum.join(', ')}`)
+        }
+
+        host = host.replace(`{${option}}`, hostOption)
+    }
+
+    return host
+}
+
+/**
+ * helper to generate host for assets, like:
+ * https://assets.saucelabs.com/jobs/<jobId>/selenium-server.log
+ * https://assets.eu-central-1.saucelabs.com/jobs/<jobId>/log.json
+ * https://assets.us-east-1.saucelabs.com/jobs/<jobId>/log.json
+ * https://assets.staging.saucelabs.net/jobs/<jobId>/log.json
+ */
+export function getAssetHost (options) {
+    if (options.headless) {
+        options.region = 'us-east-1'
+    }
+
+    if (options.region === 'staging') {
+        options.tld = options.tld || 'net'
+    }
+
+    const tld = options.tld || 'com'
+    const region = ASSET_REGION_MAPPING[options.region] || ''
+    return `https://assets.${region}saucelabs.${tld}`
 }
 
 /**

--- a/tests/__mocks__/form-data.js
+++ b/tests/__mocks__/form-data.js
@@ -1,0 +1,9 @@
+const instances = []
+
+export default class FormDataMock {
+    constructor () {
+        this.append = jest.fn()
+        this.instances = instances
+        instances.push(this)
+    }
+}

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -9,7 +9,7 @@ Array [
       "--tunnel-identifier=my-tunnel",
       "--user=foo",
       "--api-key=bar",
-      "--rest-url=https://us-east-1.saucelabs.com/rest/v1",
+      "--rest-url=https://api.us-east-1.saucelabs.com/rest/v1",
     ],
   ],
 ]

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -59,6 +59,12 @@ test('should return public properties', () => {
     expect(api._accessKey).toBe(undefined)
 })
 
+test('should return nothing if Symbol was accessed', () => {
+    const sym = Symbol('foo')
+    const api = new SauceLabs({ user: 'foo', key: 'bar' })
+    expect(typeof api[sym]).toBe('undefined')
+})
+
 test('should grab username and access key from env variable', () => {
     jest.resetModules()
     process.env.SAUCE_USERNAME = 'barfoo'

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,6 +1,7 @@
 import util from 'util'
 import got from 'got'
 import { spawn } from 'child_process'
+import FormData from 'form-data'
 
 import SauceLabs from '../src'
 import { instances } from 'bin-wrapper'
@@ -106,7 +107,7 @@ test('should allow to call an API method with param in url', async () => {
     const api = new SauceLabs({ user: 'foo', key: 'bar' })
     await api.getUserConcurrency('someuser')
     expect(got.mock.calls[0][0])
-        .toBe('https://saucelabs.com/rest/v1.1/users/someuser/concurrency')
+        .toBe('https://api.us-west-1.saucelabs.com/rest/v1.1/users/someuser/concurrency')
 })
 
 test('should allow to call an API method with param as option', async () => {
@@ -118,7 +119,7 @@ test('should allow to call an API method with param as option', async () => {
 
     const uri = got.mock.calls[0][0]
     const req = got.mock.calls[0][1]
-    expect(uri).toBe('https://saucelabs.com/rest/v1.1/someuser/jobs')
+    expect(uri).toBe('https://api.us-west-1.saucelabs.com/rest/v1.1/someuser/jobs')
     expect(req.searchParams).toEqual({
         limit: 123,
         full: true
@@ -252,6 +253,46 @@ test('should put asset into file as json file', async () => {
     const api = new SauceLabs({ user: 'foo', key: 'bar' })
     await api.downloadJobAsset('some-id', 'performance.json', { filepath: '/asset.json' })
     expect(fs.writeFileSync).toBeCalledWith('/asset.json', undefined, { encoding: 'utf8' })
+})
+
+test('should allow to upload files', async () => {
+    fs.createReadStream.mockReturnValue({
+        name: '/somefile',
+        path: 'somepath',
+    })
+
+    const api = new SauceLabs({ user: 'foo', key: 'bar' })
+    const body = { foo: 'bar' }
+    got.get = jest.fn().mockReturnValue(Promise.resolve({
+        headers: {
+            'content-type': 'application/json'
+        },
+        body: JSON.stringify(body)
+    }))
+    const result = await api.uploadJobAssets('some-id', ['log.json', 'selenium-server.json'])
+
+    const { instances } = new FormData()
+    expect(instances[0].append).toBeCalledTimes(2)
+    expect(instances[0].append).toBeCalledWith('file[]', {name: '/somefile', path: 'somepath'})
+
+    const uri = got.get.mock.calls[0][0]
+    expect(uri).toBe('https://api.us-west-1.saucelabs.com/v1/testrunner/jobs/some-id/assets')
+
+    expect(result).toEqual(body)
+})
+
+test('should throw if custom error if upload fails', async () => {
+    fs.createReadStream.mockReturnValue({
+        name: '/somefile',
+        path: 'somepath',
+    })
+
+    const api = new SauceLabs({ user: 'foo', key: 'bar' })
+    got.get = jest.fn().mockReturnValue(Promise.reject(new Error('uups')))
+    const result = await api.uploadJobAssets('some-id', ['log.json', 'selenium-server.json'])
+        .catch((err) => err)
+
+    expect(result.message).toBe('There was an error uploading assets: uups')
 })
 
 describe('startSauceConnect', () => {

--- a/tests/typings/test.ts
+++ b/tests/typings/test.ts
@@ -15,7 +15,7 @@ async function foobar () {
     const sc = await api.startSauceConnect({
         scVersion: '4.5.4',
         tunnelIdentifier: '1234',
-        logger: (output) => console.log(output)
+        logger: (output: string) => console.log(output)
     })
     sc.cp.pid
     await sc.close()

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -69,7 +69,7 @@ test('toString', () => {
         _accessKey: '50fc1a11-3231-4240-9707-8f34682b17b0',
         _options: { region: 'us', headless: false }
     })).toBe(`SauceLabs API Client {
-  user: 'foobar',
+  username: 'foobar',
   key: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXX2b17b0',
   region: 'us',
   headless: false,


### PR DESCRIPTION
With the Sauce Labs Testrunner Toolkit we introduced a new endpoint that allows anyone to upload assets to his job. This is a new microservice with a new OpenAPI spec. The new command can be used as follows:

via CLI:
```sh
sl uploadJobAssets 690c5877710c422d8be4c622b40c747f --files ./video.mp4 --files ./log.json
```

or via Node.js
```js
await myAccount.uploadJobAssets(
    '76e693dbe6ff4910abb0bc3d752a971e',
    ['video.mp4', 'log.json']
)
```