### PR TITLE
fix: rejectUnauthorized deprecation warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ export default class SauceLabs {
         this._api = got.extend({
             username: this.username,
             password: this._accessKey,
-            rejectUnauthorized: getStrictSsl(),
+            https: { rejectUnauthorized: getStrictSsl() },
             followRedirect: true,
         })
 


### PR DESCRIPTION
Fix for: 
"DeprecationWarning: Got: "options.rejectUnauthorized" is now deprecated, please use "options.https.rejectUnauthorized""
when running saucelabs with webdriverio