### PR TITLE
Don't overwrite rest-url flag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -223,10 +223,12 @@ export default class SauceLabs {
              */
             .filter(([k]) => !k.match(/[A-Z]/g))
             .map(([k, v]) => `--${k}=${v}`)
-
         args.push(`--user=${this.username}`)
         args.push(`--api-key=${this._accessKey}`)
-        args.push(`--rest-url=${restUrl}`)
+
+        if (!args.some(arg => arg.startsWith("--rest-url"))) {
+            args.push(`--rest-url=${restUrl}`)
+        }
 
         const bin = SAUCE_CONNECT_DISTS.reduce((bin, [downloadUrl, ...args]) => {
             bin.src(util.format(downloadUrl, sauceConnectVersion), ...args)

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,7 +39,7 @@ export function getAPIHost (servers, basePath, options) {
      * allows to set an arbitrary host (for internal use only)
      */
     const apiUrl = options.host || servers[0].url
-    let host = DEFAULT_PROTOCOL + path.join(apiUrl.replace(DEFAULT_PROTOCOL, ''), basePath)
+    let host = DEFAULT_PROTOCOL + apiUrl.replace(DEFAULT_PROTOCOL, '') + basePath
 
     /**
      * allow short region handles to stay backwards compatible

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`startSauceConnect should not overwrite rest-url if given as a parameter 1`] = `
+Array [
+  Array [
+    "/foo/bar",
+    Array [
+      "--tunnel-identifier=my-tunnel",
+      "--rest-url=https://us1.api.testobject.com/sc/rest/v1",
+      "--user=foo",
+      "--api-key=bar",
+    ],
+  ],
+]
+`;
+
 exports[`startSauceConnect should start sauce connect with proper parsed args 1`] = `
 Array [
   Array [

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -357,6 +357,16 @@ describe('startSauceConnect', () => {
         const res = await api.startSauceConnect({ tunnelIdentifier: 'my-tunnel' }).catch((err) => err)
         expect(res).toEqual(new Error('Uuups'))
     })
+
+    it('should not overwrite rest-url if given as a parameter', async () => {
+        const api = new SauceLabs({ user: 'foo', key: 'bar'})
+        setTimeout(() => stdoutEmitter.emit('data', 'Sauce Connect is up, you may start your tests'), 50)
+        await api.startSauceConnect({
+            tunnelIdentifier: 'my-tunnel',
+            restUrl: 'https://us1.api.testobject.com/sc/rest/v1'
+        })
+        expect(spawn.mock.calls).toMatchSnapshot()
+    })
 })
 
 afterEach(() => {


### PR DESCRIPTION
This PR does two things:

- Fixes #88 by checking if a --rest-url flag is used and does not add the one decided by region if that is the case.
- Fixes #84 by not using path.join for creating the API host URL as it breaks Sauce Connect on Windows.

Tested this on a Windows 10 machine and the URL gets created as it should.