### PR TITLE
change concurrency endpoint to v1.2

### DIFF
--- a/apis/sauce.json
+++ b/apis/sauce.json
@@ -226,7 +226,7 @@
       "properties":{
         "concurrency":{
           "additionalProperties":{
-            "$ref":"#/definitions/SubAccountConcurrencyValues"
+            "$ref":"#/definitions/OrgTeamConcurrencyValues"
           },
           "type":"object"
         },
@@ -260,14 +260,17 @@
     },
     "ConcurrencyValues":{
       "properties":{
-        "mac":{
+        "mac_vms":{
           "type":"integer"
         },
-        "manual":{
+        "rds":{
           "type":"integer"
         },
-        "overall":{
+        "vms":{
           "type":"integer"
+        },
+        "id":{
+          "type":"string"
         }
       },
       "type":"object"
@@ -507,12 +510,12 @@
       },
       "type":"object"
     },
-    "SubAccountConcurrencyValues":{
+    "OrgTeamConcurrencyValues":{
       "properties":{
         "current":{
           "$ref":"#/definitions/ConcurrencyValues"
         },
-        "remaining":{
+        "allowed":{
           "$ref":"#/definitions/ConcurrencyValues"
         }
       },
@@ -969,7 +972,7 @@
         ]
       }
     },
-    "/v1.1/users/{username}/concurrency":{
+    "/v1.2/users/{username}/concurrency":{
       "get":{
         "operationId":"get_user_concurrency",
         "parameters":[

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -107,7 +107,7 @@ test('should allow to call an API method with param in url', async () => {
     const api = new SauceLabs({ user: 'foo', key: 'bar' })
     await api.getUserConcurrency('someuser')
     expect(got.mock.calls[0][0])
-        .toBe('https://api.us-west-1.saucelabs.com/rest/v1.1/users/someuser/concurrency')
+        .toBe('https://api.us-west-1.saucelabs.com/rest/v1.2/users/someuser/concurrency')
 })
 
 test('should allow to call an API method with param as option', async () => {


### PR DESCRIPTION
**Summary**
Now that all customers are on xTM the v1.1 no longer accurately represent the concurrency of a user.
The v1.2 endpoint groups concurrency by team and org giving a more detailed view on how a team uses concurrency and what's available across the organization

There is no need to keep v1.2 as no one is on the old team management anymore.

fixes #76 