### PR TITLE
proxy typings ask for object instead of string

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Default: `false`
 
 ### proxy
 
-If you want to tunnel your API request through a proxy please see the [got proxy docs](https://github.com/sindresorhus/got/blob/master/readme.md#proxies) for more information.
+If you want to tunnel your API request through a proxy please provide your proxy URL.
 
-Type: `object`<br>
+Type: `string`<br>
 Default: `null`
 
 ## Usage

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -28,9 +28,9 @@ export interface SauceLabsOptions {
      */
     headless?: boolean;
     /**
-     * If you want to tunnel your API request through a proxy please see the [got proxy docs](https://github.com/sindresorhus/got/blob/master/readme.md#proxies) for more information.
+     * If you want to tunnel your API request through a proxy please provide your proxy URL.
      */
-    proxy?: object;
+    proxy?: string;
 }`
 
 exports.TC_SAUCE_CONNECT_OBJ = `

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ export default class SauceLabs {
             followRedirect: true,
         })
 
-        if (this._options.proxy !== undefined) {
+        if (typeof this._options.proxy === 'string') {
             var proxyAgent = createProxyAgent(this._options.proxy)
             this._api = got.extend({
                 agent: proxyAgent

--- a/tests/typings/test.ts
+++ b/tests/typings/test.ts
@@ -4,7 +4,7 @@ const api = new SauceLabs({
     region: 'eu',
     user: 'foo',
     key: 'foobar',
-    proxy: {},
+    proxy: 'barfoo',
     headless: false
 });
 


### PR DESCRIPTION
The proxy options as well as the typings define the option as object while in reality it should be provided as a string. This should be cleaned up as we have started to have [a helper](https://github.com/saucelabs/node-saucelabs/blob/a66856fd878b3be66df2afc24aaff8d34999c5c0/src/utils.js#L141-L170) for it.