### PR TITLE
Always pull latest Sauce Connect version if not specified otherwise

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -5,6 +5,7 @@ import { version } from '../package.json'
 
 export const DEFAULT_SAUCE_CONNECT_VERSION = '4.6.2'
 export const SAUCE_CONNECT_BASE = 'https://saucelabs.com/downloads'
+export const SAUCE_CONNECT_VERSIONS_ENDPOINT = 'https://saucelabs.com/versions.json'
 export const SAUCE_CONNECT_DISTS = [
     [`${SAUCE_CONNECT_BASE}/sc-%s-osx.zip`, 'darwin'],
     [`${SAUCE_CONNECT_BASE}/sc-%s-win32.zip`, 'win32'],

--- a/tests/__responses__/versions.json
+++ b/tests/__responses__/versions.json
@@ -1,0 +1,30 @@
+{
+    "Sauce Connect": {
+        "download_url": "https://wiki.saucelabs.com/display/DOCS/Setting+Up+Sauce+Connect",
+        "linux": {
+            "build": 5183,
+            "download_url": "https://saucelabs.com/downloads/sc-4.6.2-linux.tar.gz",
+            "sha1": "7b7f35433af9c3380758e048894d7b9aecf3754e"
+        },
+        "linux32": {
+            "build": 5183,
+            "download_url": "https://saucelabs.com/downloads/sc-4.6.2-linux32.tar.gz",
+            "sha1": "ce96d8543f013e0112a678aa9980e95331421cb1"
+        },
+        "osx": {
+            "build": 5183,
+            "download_url": "https://saucelabs.com/downloads/sc-4.6.2-osx.zip",
+            "sha1": "51c6c152eb54c20d8969a9d5917ebecc3ac868e1"
+        },
+        "version": "1.2.4",
+        "win32": {
+            "build": 5183,
+            "download_url": "https://saucelabs.com/downloads/sc-4.6.2-win32.zip",
+            "sha1": "4b8955c806998226ed41592cbe45c929c0f88a87"
+        }
+    },
+    "Sauce Connect 2": {
+        "download_url": "https://docs.saucelabs.com/reference/sauce-connect/",
+        "version": "4.3.13-r999"
+    }
+}


### PR DESCRIPTION
Fallback to hardcoded version in case the API call fails.

Closes #93 