### PR TITLE
Add API for creating job via test-composer

### DIFF
--- a/apis/testrunner.json
+++ b/apis/testrunner.json
@@ -159,7 +159,7 @@
           "Job"
         ],
         "responses": {
-          "200": {
+          "201": {
             "description": "create result job",
             "content": {
               "application/json": {

--- a/apis/testrunner.json
+++ b/apis/testrunner.json
@@ -136,6 +136,41 @@
           }
         }
       }
+    },
+    "/jobs": {
+      "post": {
+        "operationId":"createJob",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "parameters",
+            "required": true,
+            "description": "create result job request body",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "externalDocs": {
+          "description": "TBD",
+          "url": "https://wiki.saucelabs.com"
+        },
+        "tags": [
+          "Job"
+        ],
+        "responses": {
+          "200": {
+            "description": "create result job",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "json"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Create this API for creating job via test-composer. This is an internal API and a work around for creating job currently.
Usage:
```
./bin/sl createJob '{}'
```