### PR TITLE
uploadJobAssets needs a file instead of a buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,17 @@ import SauceLabs from 'saucelabs';
     // upload additional log files and attach it to your Sauce job
     await myAccount.uploadJobAssets(
         '76e693dbe6ff4910abb0bc3d752a971e',
-        ['video.mp4', 'log.json']
+        [
+            // either pass in file names
+            './logs/video.mp4', './logs/log.json',
+            // or file objects
+            {
+                filename: 'myCustomLogFile.json',
+                data: {
+                    someLog: 'data'
+                }
+            }
+        ]
     )
 })()
 ```

--- a/apis/testrunner.json
+++ b/apis/testrunner.json
@@ -57,7 +57,7 @@
       }
     },
     "files": {
-      "description": "s path to upload and attach to your job",
+      "description": "asset to upload and attach to your job",
       "in": "path",
       "name": "files",
       "required": false,

--- a/src/index.js
+++ b/src/index.js
@@ -358,12 +358,18 @@ export default class SauceLabs {
         const uri = getAPIHost(servers, basePath, this._options) + endpoint.replace('{jobId}', jobId)
         const body = new FormData()
 
-        for (const filePath of files) {
-            const readStream = fs.createReadStream(filePath.startsWith('/')
-                ? filePath
-                : path.join(process.cwd(), filePath)
-            )
-            body.append('file[]', readStream)
+        for (const file of files) {
+            if (typeof file === 'string') {
+                const readStream = fs.createReadStream(file.startsWith('/')
+                    ? file
+                    : path.join(process.cwd(), file)
+                )
+                body.append('file[]', readStream)
+            } else if (file && typeof file.filename === 'string') {
+                body.append('file[]', Buffer.from(JSON.stringify(file.data)), file.filename)
+            } else {
+                throw new Error('Invalid file parameter! Expected either a file path or a file object containing "filename" and "data" property.')
+            }
         }
 
         try {


### PR DESCRIPTION
The current `uploadJobAssets ` requests a file which results in storing the buffer into a file and then upload it to Sauce. Can we change this to a buffer and let the module handle this?