### PR TITLE
Update endpoint for creating job via test-composer

### DIFF
--- a/apis/testrunner.json
+++ b/apis/testrunner.json
@@ -137,7 +137,7 @@
         }
       }
     },
-    "/jobs": {
+    "/reports": {
       "post": {
         "operationId":"createJob",
         "parameters": [


### PR DESCRIPTION
We've modified the endpoint to `/rest/v1/reports` but forgot to change here.