### PR TITLE
Show err response body for createJob API

### DIFF
--- a/apis/testrunner.json
+++ b/apis/testrunner.json
@@ -168,6 +168,16 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "invalid parameters",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -199,7 +199,7 @@ export default class SauceLabs {
                 return response.body
             } catch (err) {
                 if (propName === 'createJob') {
-                    throw new Error(`Failed calling ${propName}: ${err.message}, ${err.response.body}`)
+                    throw new Error(`Failed calling ${propName}: ${err.message}, ${err.response && err.response.body}`)
                 }
                 throw new Error(`Failed calling ${propName}: ${err.message}`)
             }

--- a/src/index.js
+++ b/src/index.js
@@ -196,9 +196,11 @@ export default class SauceLabs {
                     ),
                     responseType: 'json'
                 })
-
                 return response.body
             } catch (err) {
+                if (propName === 'createJob') {
+                    throw new Error(`Failed calling ${propName}: ${err.message}, ${err.response.body}`)
+                }
                 throw new Error(`Failed calling ${propName}: ${err.message}`)
             }
         }

--- a/src/index.js
+++ b/src/index.js
@@ -198,10 +198,7 @@ export default class SauceLabs {
                 })
                 return response.body
             } catch (err) {
-                if (propName === 'createJob') {
-                    throw new Error(`Failed calling ${propName}: ${err.message}, ${err.response && err.response.body}`)
-                }
-                throw new Error(`Failed calling ${propName}: ${err.message}`)
+                throw new Error(`Failed calling ${propName}: ${err.message}, ${err.response && err.response.body}`)
             }
         }
     }

--- a/tests/__mocks__/got.js
+++ b/tests/__mocks__/got.js
@@ -3,6 +3,7 @@ const gotMock = jest.fn()
     .mockImplementation(() => Promise.resolve({ statusCode: 200, headers }))
 gotMock.get = gotMock
 gotMock.put = gotMock
+gotMock.post = gotMock
 gotMock.extend = jest.fn().mockReturnValue(gotMock)
 gotMock.setHeader = (header) => (headers = header)
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -214,7 +214,7 @@ test('should handle error case', async () => {
         limit: 123,
         full: true
     }).catch((err) => err)
-    expect(error.message).toBe('Failed calling listJobs: Not Found')
+    expect(error.message).toContain('Failed calling listJobs: Not Found')
 })
 
 test('should be able to download assets', async () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -454,6 +454,18 @@ describe('startSauceConnect', () => {
     })
 })
 
+test('should output failure msg for createJob API', async () => {
+    const response = new Error('Response code 422 (Unprocessable Entity)')
+    response.statusCode = 422
+    response.response = {body: 'empty framework'}
+    got.post.mockReturnValue(Promise.reject(response))
+
+    const api = new SauceLabs({ user: 'foo', key: 'bar' })
+    const error = await api.createJob({framework: ''}).catch((err) => err)
+
+    expect(error.message).toBe('Failed calling createJob: Response code 422 (Unprocessable Entity), empty framework')
+})
+
 afterEach(() => {
     fs.writeFileSync.mockClear()
     got.mockClear()


### PR DESCRIPTION
For `createJob` API, it explains why it failed in response body. But when calling this API in node-saucelabs, it only outputs `err.message`. It's not enough to figure out which part is wrong with current implementation. I only added `err.response.body` for `createJob` API cause it will be deprecated in the future. Hope this change doesn't affect other APIs.
Before:
```
 ./bin/sl createJob '{}'
Error: Failed calling createJob: Response code 422 (Unprocessable Entity)
```
After:
```
 ./bin/sl createJob '{}'
Error: Failed calling createJob: Response code 422 (Unprocessable Entity), empty framework
```
Other APIs:
```
./bin/sl updateJob cb-onboarding xxxxx "{}"
Error: Failed calling updateJob: Response code 404 (Not Found)
```