### PR TITLE
Improve `uploadJobAssets` command

### DIFF
--- a/apis/testrunner.json
+++ b/apis/testrunner.json
@@ -1,5 +1,5 @@
 {
-  "openapi":"3.0.0",
+  "swagger":"2.0",
   "info":{
     "description":"A service that orchestrates the Sauce cloud as well as test runner packages.",
     "version":"0.1.7",
@@ -61,7 +61,12 @@
       "in": "path",
       "name": "files",
       "required": false,
-      "type": "string"
+      "schema": {
+        "items":{
+          "type":"string"
+        },
+        "type":"array"
+      }
     }
   },
   "components":{

--- a/src/index.js
+++ b/src/index.js
@@ -359,11 +359,18 @@ export default class SauceLabs {
 
         for (const file of files) {
             if (typeof file === 'string') {
-                const readStream = fs.createReadStream(file.startsWith('/')
+                const filename = file.startsWith('/')
                     ? file
                     : path.join(process.cwd(), file)
-                )
-                body.append('file[]', readStream)
+                const readStream = fs.createReadStream(filename)
+                const stats = await fs.promises.stat(filename)
+
+                body.append('file[]', readStream, {
+                    filename: path.basename(file),
+                    filepath: filename,
+                    contentType: 'text/plain',
+                    knownLength: stats.size
+                })
             } else if (file && typeof file.filename === 'string') {
                 body.append('file[]', Buffer.from(JSON.stringify(file.data)), file.filename)
             } else {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -10,6 +10,9 @@ import {DEFAULT_SAUCE_CONNECT_VERSION} from '../src/constants'
 
 jest.mock('fs')
 const fs = require('fs')
+fs.promises = {
+    stat: jest.fn().mockReturnValue(Promise.resolve({ size: 123 }))
+}
 
 jest.mock('child_process', () => {
     const EventEmitter = require('events')
@@ -306,7 +309,16 @@ test('should allow to upload files', async () => {
 
     const { instances } = new FormData()
     expect(instances[0].append).toBeCalledTimes(3)
-    expect(instances[0].append).toBeCalledWith('file[]', {name: '/somefile', path: 'somepath'})
+    expect(instances[0].append).toBeCalledWith(
+        'file[]',
+        { name: '/somefile', path: 'somepath' },
+        {
+            contentType: 'text/plain',
+            filename: 'log.json',
+            filepath: expect.any(String),
+            knownLength: 123
+        }
+    )
     expect(instances[0].append).toBeCalledWith('file[]', Buffer.from(JSON.stringify({ foo: 'bar' })), 'foobar.json')
 
     const uri = got.mock.calls[0][0]

--- a/tests/typings/test.ts
+++ b/tests/typings/test.ts
@@ -22,6 +22,7 @@ async function foobar () {
 
     await api.downloadJobAsset( 'job_id', 'video.mp4')
     await api.downloadJobAsset( 'job_id', 'video.mp4', './video.mp4')
+    await api.uploadJobAssets('foobar', ['foo', 'bar'])
 
     api.username.slice(1, 1)
     api.region.slice(1, 1)


### PR DESCRIPTION
This patch improves the `uploadJobAssets` command by:

- adding it to the type definition
- adding more meta data if the file is a file path
