### PR TITLE
Use newer test-composer endpoint

### DIFF
--- a/apis/testcomposer.json
+++ b/apis/testcomposer.json
@@ -1,9 +1,9 @@
 {
   "swagger":"2.0",
   "info":{
-    "description":"A service that orchestrates the Sauce cloud as well as test runner packages.",
+    "description":"A service that orchestrates the Sauce Cloud.",
     "version":"0.1.7",
-    "title":"Testrunner Orchestrator",
+    "title":"Test-Composer",
     "termsOfService":"https://saucelabs.com/terms-of-service",
     "contact":{
       "name":"Open Source Program Office at Sauce",
@@ -12,10 +12,10 @@
     }
   },
   "externalDocs":{
-    "description":"Sauce Labs Wiki",
-    "url":"https://wiki.saucelabs.com"
+    "description":"Sauce Labs Docs",
+    "url":"https://docs.saucelabs.com"
   },
-  "basePath": "/v1/testrunner",
+  "basePath": "/v1/testcomposer",
   "servers":[
     {
       "url":"https://api.{region}.saucelabs.{tld}",

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,7 +18,7 @@ const protocols = [
     require('../apis/sauce.json'),
     require('../apis/rdc.json'),
     require('../apis/performance.json'),
-    require('../apis/testrunner.json'),
+    require('../apis/testcomposer.json'),
     require('../apis/datastore.json'),
     require('../apis/autonomiq.json')
 ]

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -322,7 +322,7 @@ test('should allow to upload files', async () => {
     expect(instances[0].append).toBeCalledWith('file[]', Buffer.from(JSON.stringify({ foo: 'bar' })), 'foobar.json')
 
     const uri = got.mock.calls[0][0]
-    expect(uri).toBe('https://api.us-west-1.saucelabs.com/v1/testrunner/jobs/some-id/assets')
+    expect(uri).toBe('https://api.us-west-1.saucelabs.com/v1/testcomposer/jobs/some-id/assets')
 
     expect(result).toEqual(body)
 })


### PR DESCRIPTION
The old one was deprecated a year ago.