### PR TITLE
File Upload: Support for buffer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -374,6 +374,8 @@ export default class SauceLabs {
                     contentType: 'text/plain',
                     knownLength: stats.size
                 })
+            } else if (file && typeof file.filename === 'string' && Buffer.isBuffer(file.data)) {
+                body.append('file[]', file.data, file.filename)
             } else if (file && typeof file.filename === 'string') {
                 body.append('file[]', Buffer.from(JSON.stringify(file.data)), file.filename)
             } else {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -301,6 +301,10 @@ test('should allow to upload files', async () => {
             'log.json',
             'selenium-server.json',
             {
+                filename: 'raw-file.json',
+                data: Buffer.from('my-raw-data', 'utf8')
+            },
+            {
                 filename: 'foobar.json',
                 data: { foo: 'bar' }
             }
@@ -308,7 +312,7 @@ test('should allow to upload files', async () => {
     })
 
     const { instances } = new FormData()
-    expect(instances[0].append).toBeCalledTimes(3)
+    expect(instances[0].append).toBeCalledTimes(4)
     expect(instances[0].append).toBeCalledWith(
         'file[]',
         { name: '/somefile', path: 'somepath' },
@@ -319,6 +323,7 @@ test('should allow to upload files', async () => {
             knownLength: 123
         }
     )
+    expect(instances[0].append).toBeCalledWith('file[]', Buffer.from('my-raw-data', 'utf8'), 'raw-file.json')
     expect(instances[0].append).toBeCalledWith('file[]', Buffer.from(JSON.stringify({ foo: 'bar' })), 'foobar.json')
 
     const uri = got.mock.calls[0][0]


### PR DESCRIPTION
Currently, when providing a buffer in `_uploadJobAssets`, it's stringified + transformed into a buffer.

When trying to upload an asset which is a binary file read from the disk, it break the file.
This fix is to avoid that.

**_Use case:_**
Uploading a media and rename it. To avoid writing on the disk, reading the file + passing it as a buffer with a specified filename is more convenient.

Real world use-case: https://github.com/saucelabs/sauce-cypress-plugin/pull/2/files#diff-a30b901031c7401c0e5f13a547d0054062e611908d18401734d91132169e8ad0R111
