### PR TITLE
Make query-string a dependency instead of devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "saucelabs",
-      "version": "7.1.3",
+      "version": "7.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "change-case": "^4.1.2",
@@ -14,6 +14,7 @@
         "form-data": "^4.0.0",
         "got": "^11.8.2",
         "hash.js": "^1.1.7",
+        "query-string": "^7.0.1",
         "tunnel": "^0.0.6",
         "yargs": "^17.2.1"
       },
@@ -35,7 +36,6 @@
         "lint-staged": "^12.4.1",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.6.2",
-        "query-string": "^7.0.1",
         "release-it": "^14.11.6",
         "rimraf": "^3.0.2",
         "source-map-support": "^0.5.20",
@@ -6019,7 +6019,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
       "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11408,7 +11407,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
       "integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
-      "dev": true,
       "dependencies": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -12286,7 +12284,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
       "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -12322,7 +12319,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
       "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -18338,8 +18334,7 @@
     "filter-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
-      "dev": true
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
     },
     "find-cache-dir": {
       "version": "2.1.0",
@@ -22369,7 +22364,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
       "integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
-      "dev": true,
       "requires": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -23032,8 +23026,7 @@
     "split-on-first": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "dev": true
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -23061,8 +23054,7 @@
     "strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
-      "dev": true
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "form-data": "^4.0.0",
     "got": "^11.8.2",
     "hash.js": "^1.1.7",
+    "query-string": "^7.0.1",
     "tunnel": "^0.0.6",
     "yargs": "^17.2.1"
   },
@@ -62,7 +63,6 @@
     "lint-staged": "^12.4.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.6.2",
-    "query-string": "^7.0.1",
     "release-it": "^14.11.6",
     "rimraf": "^3.0.2",
     "source-map-support": "^0.5.20",


### PR DESCRIPTION
`query-string` is used in the production code of this package, so it should be a `dependency` instead of a `devDependency`, to ensure that it is installed: https://github.com/saucelabs/node-saucelabs/blob/7e9c5fba5457ae144f748b2eb70acd25c1661cef/src/index.js#L8

Fixes https://github.com/saucelabs/node-saucelabs/issues/143