### PR TITLE
Setting Sauce Connect default to sc-4.8.1 release

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -3,7 +3,7 @@ import os from 'os';
 
 import {version} from '../package.json';
 
-export const DEFAULT_SAUCE_CONNECT_VERSION = '4.8.0';
+export const DEFAULT_SAUCE_CONNECT_VERSION = '4.8.1';
 export const SAUCE_CONNECT_BASE = 'https://saucelabs.com/downloads';
 export const SAUCE_CONNECT_VERSIONS_ENDPOINT =
   'https://saucelabs.com/versions.json';


### PR DESCRIPTION
Can be merged after SC-4.8.1 release is announced and [SC docs](https://docs.saucelabs.com/secure-connections/sauce-connect/installation/) are updated