### PR TITLE
resolves #245

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -25,13 +25,9 @@ export interface SauceLabsOptions {
      *
      * - us-west-1 (short 'us')
      * - eu-central-1 (short 'eu')
-     * - us-east-1 (headless)
+     * - us-east-1
      */
     region?: ${regions};
-    /**
-     * If set to true you are accessing the headless Sauce instances (this discards the region option).
-     */
-    headless?: boolean;
     /**
      * If you want to tunnel your API request through a proxy please provide your proxy URL.
      */

--- a/scripts/generate-typings.js
+++ b/scripts/generate-typings.js
@@ -89,7 +89,6 @@ fs.readdir(path.join(__dirname, '../apis'), (err, files) => {
     username: string;
     region: string;
     tld: string;
-    headless: boolean;
     webdriverEndpoint: string;\n\n
     ${methods}
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -47,12 +47,12 @@ export const run = () => {
         }
       },
       async (argv) => {
-        const {user, key, headless, region, proxy, tld} = Object.assign(
+        const {user, key, region, proxy, tld} = Object.assign(
           {},
           DEFAULT_OPTIONS,
           argv
         );
-        const api = new SauceLabs({user, key, headless, region, proxy, tld});
+        const api = new SauceLabs({user, key, region, proxy, tld});
         const requiredParams = params
           .filter((p) => p.required)
           .map((p) => argv[p.name]);

--- a/src/commands/sc.js
+++ b/src/commands/sc.js
@@ -9,11 +9,7 @@ export const builder = (yargs) => {
   }
 };
 export const handler = async (argv) => {
-  const {user, key, headless, region, proxy} = Object.assign(
-    {},
-    DEFAULT_OPTIONS,
-    argv
-  );
-  const api = new SauceLabs({user, key, headless, region, proxy});
+  const {user, key, region, proxy} = Object.assign({}, DEFAULT_OPTIONS, argv);
+  const api = new SauceLabs({user, key, region, proxy});
   return api.startSauceConnect(argv, true);
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -87,7 +87,6 @@ export const JOB_ASSET_NAMES = [
 export const DEFAULT_OPTIONS = {
   user: process.env.SAUCE_USERNAME,
   key: process.env.SAUCE_ACCESS_KEY,
-  headless: false,
   region: 'us',
   proxy: process.env.HTTPS_PROXY || process.env.HTTP_PROXY,
   headers: {'User-Agent': `saucelabs/v${version} (nodejs ${os.platform()})`},
@@ -135,13 +134,6 @@ export const CLI_PARAMS = [
     default: DEFAULT_OPTIONS.region,
     description:
       'your Sauce Labs datacenter region, the following regions are available: `us-west-1` (short `us`), `eu-central-1` (short `eu`)',
-  },
-  {
-    name: 'headless',
-    default: DEFAULT_OPTIONS.headless,
-    description:
-      'if set to true you are accessing the headless Sauce instances (this discards the `region` option)',
-    boolean: true,
   },
   {
     alias: 'p',

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,6 @@ export default class SauceLabs {
      */
     this.region = this._options.region;
     this.tld = this._options.tld;
-    this.headless = this._options.headless;
     this.webdriverEndpoint = `https://ondemand.${getRegionSubDomain(
       options
     )}.saucelabs.com/`;
@@ -84,7 +83,6 @@ export default class SauceLabs {
           -6
         )}`,
         region: this._options.region,
-        headless: this._options.headless,
         proxy: this._options.proxy,
         webdriverEndpoint: this.webdriverEndpoint,
         headers: this._options.headers,

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,7 +37,6 @@ export function getRegionSubDomain(options = {}) {
 
   if (options.region === 'us') region = 'us-west-1';
   if (options.region === 'eu') region = 'eu-central-1';
-  if (options.headless) region = 'us-east-1';
   return region;
 }
 
@@ -46,7 +45,7 @@ export function getRegionSubDomain(options = {}) {
  * @param  {string}  servers   OpenAPI spec servers property
  * @param  {string}  basePath  OpenAPI spec base path
  * @param  {object}  options   client options
- * @return {string}            endpoint base url (e.g. `https://us-east1.headless.saucelabs.com`)
+ * @return {string}            endpoint base url (e.g. `https://api.us-west-1.saucelabs.com`)
  */
 export function getAPIHost(servers, basePath, options) {
   /**
@@ -90,10 +89,6 @@ export function getAPIHost(servers, basePath, options) {
  * https://assets.staging.saucelabs.net/jobs/<jobId>/log.json
  */
 export function getAssetHost(options) {
-  if (options.headless) {
-    options.region = 'us-east-1';
-  }
-
   if (options.region === 'staging') {
     options.tld = options.tld || 'net';
   }
@@ -113,7 +108,6 @@ export function toString(scope) {
   username: '${scope.username}',
   key: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXX${scope._accessKey.slice(-6)}',
   region: '${scope._options.region}',
-  headless: ${scope._options.headless},
   proxy: ${scope._options.proxy}
 }`;
 }

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -50,8 +50,7 @@ test('should be able to execute a command', async () => {
   const params = {
     user: 'foobaruser',
     key: 'barfookey',
-    headless: true,
-    region: 'anywhere',
+    region: 'eu',
     username: 'username-param',
     limit: 42,
     subaccounts: true,
@@ -62,8 +61,7 @@ test('should be able to execute a command', async () => {
   expect(api.options).toEqual({
     user: 'foobaruser',
     key: 'barfookey',
-    headless: true,
-    region: 'anywhere',
+    region: 'eu',
   });
   expect(api.listJobs).toBeCalledWith('username-param', params);
 });

--- a/tests/commands/sc.test.js
+++ b/tests/commands/sc.test.js
@@ -21,7 +21,7 @@ test('builder', () => {
 });
 
 test('handler', async () => {
-  const api = await handler({headless: true});
+  const api = await handler({region: 'eu'});
   expect(api.scStarted).toBe(true);
-  expect(api.startSauceConnect).toBeCalledWith({headless: true}, true);
+  expect(api.startSauceConnect).toBeCalledWith({region: 'eu'}, true);
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -64,7 +64,6 @@ test('should be inspectable', () => {
   username: 'foo',
   key: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXbar',
   region: 'us',
-  headless: false,
   proxy: undefined`);
 });
 
@@ -82,8 +81,7 @@ test('should expose a webdriverEndpoint', () => {
   const api3 = new SauceLabs({
     user: 'foo',
     key: 'bar',
-    region: 'eu',
-    headless: true,
+    region: 'us-east-1',
   });
   expect(api3.webdriverEndpoint).toBe(
     'https://ondemand.us-east-1.saucelabs.com/'
@@ -463,7 +461,7 @@ test('should contain custom headers', async () => {
 describe('startSauceConnect', () => {
   it('should start sauce connect with proper parsed args', async () => {
     const logs = [];
-    const api = new SauceLabs({user: 'foo', key: 'bar', headless: true});
+    const api = new SauceLabs({user: 'foo', key: 'bar'});
     setTimeout(
       () =>
         stdoutEmitter.emit(
@@ -489,7 +487,7 @@ describe('startSauceConnect', () => {
 
   it('should start sauce connect with latest version if no version is specified in the args', async () => {
     const logs = [];
-    const api = new SauceLabs({user: 'foo', key: 'bar', headless: true});
+    const api = new SauceLabs({user: 'foo', key: 'bar'});
     got.mockReturnValue(
       Promise.resolve({
         body: {
@@ -516,7 +514,7 @@ describe('startSauceConnect', () => {
 
   it('should start sauce connect with fallback default version in case the call to the API failed', async () => {
     const logs = [];
-    const api = new SauceLabs({user: 'foo', key: 'bar', headless: true});
+    const api = new SauceLabs({user: 'foo', key: 'bar'});
     got.mockImplementation(() => {
       throw new Error('Endpoint not available!');
     });
@@ -538,7 +536,7 @@ describe('startSauceConnect', () => {
 
   it('should properly fail if connection could not be established', async () => {
     const errMessage = 'Sauce Connect could not establish a connection';
-    const api = new SauceLabs({user: 'foo', key: 'bar', headless: true});
+    const api = new SauceLabs({user: 'foo', key: 'bar'});
     setTimeout(() => stdoutEmitter.emit('data', errMessage), 50);
     const err = await api
       .startSauceConnect({
@@ -552,7 +550,7 @@ describe('startSauceConnect', () => {
 
   it('should properly fail if user is not authorized', async () => {
     const errMessage = 'Sauce Connect failed to start - 401 (Unauthorized).';
-    const api = new SauceLabs({user: 'foo', key: 'bar', headless: true});
+    const api = new SauceLabs({user: 'foo', key: 'bar'});
     setTimeout(() => stdoutEmitter.emit('data', errMessage), 50);
     const err = await api
       .startSauceConnect({
@@ -565,7 +563,7 @@ describe('startSauceConnect', () => {
   });
 
   it('should close sauce connect', async () => {
-    const api = new SauceLabs({user: 'foo', key: 'bar', headless: true});
+    const api = new SauceLabs({user: 'foo', key: 'bar'});
     setTimeout(
       () =>
         stdoutEmitter.emit(
@@ -587,7 +585,7 @@ describe('startSauceConnect', () => {
   });
 
   it('should fail if stderr is emitted', async () => {
-    const api = new SauceLabs({user: 'foo', key: 'bar', headless: true});
+    const api = new SauceLabs({user: 'foo', key: 'bar'});
     setTimeout(() => stderrEmitter.emit('data', 'Uuups'), 50);
     const res = await api
       .startSauceConnect({tunnelIdentifier: 'my-tunnel'})
@@ -596,7 +594,7 @@ describe('startSauceConnect', () => {
   });
 
   it('should not fail if stderr is expected character', async () => {
-    const api = new SauceLabs({user: 'foo', key: 'bar', headless: true});
+    const api = new SauceLabs({user: 'foo', key: 'bar'});
     setTimeout(() => stderrEmitter.emit('data', '\u001b[K'), 50);
     setTimeout(
       () =>

--- a/tests/typings/test.ts
+++ b/tests/typings/test.ts
@@ -5,7 +5,6 @@ const api = new SauceLabs({
   user: 'foo',
   key: 'foobar',
   proxy: 'barfoo',
-  headless: false,
 });
 
 async function foobar() {
@@ -27,7 +26,6 @@ async function foobar() {
   api.username.slice(1, 1);
   api.region.slice(1, 1);
   api.tld.slice(1, 1);
-  api.headless.valueOf();
   api.webdriverEndpoint.slice(1, 1);
 }
 

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -43,12 +43,6 @@ test('getAPIHost', () => {
     getAPIHost(sauceAPI.servers, sauceAPI.basePath, {region: 'us-east-1'})
   ).toBe('https://api.us-east-1.saucelabs.com/rest');
   expect(
-    getAPIHost(sauceAPI.servers, sauceAPI.basePath, {
-      region: 'us-west-1',
-      headless: true,
-    })
-  ).toBe('https://api.us-east-1.saucelabs.com/rest');
-  expect(
     getAPIHost(sauceAPI.servers, sauceAPI.basePath, {host: 'http://foobar.com'})
   ).toBe('http://foobar.com/rest');
   expect(() =>
@@ -71,12 +65,6 @@ test('getAPIHost', () => {
   expect(getAPIHost(rdcAPI.servers, rdcAPI.basePath, {})).toBe(
     'https://app.testobject.com/api/rest'
   );
-  expect(
-    getAPIHost(rdcAPI.servers, rdcAPI.basePath, {
-      region: 'us-west-1',
-      headless: true,
-    })
-  ).toBe('https://app.testobject.com/api/rest');
 });
 
 test('getAssetHost', () => {
@@ -91,12 +79,6 @@ test('getAssetHost', () => {
   expect(getAssetHost({region: 'eu-central-1'})).toBe(
     'https://assets.eu-central-1.saucelabs.com'
   );
-  expect(getAssetHost({headless: true})).toBe(
-    'https://assets.us-east-1.saucelabs.com'
-  );
-  expect(getAssetHost({headless: true, region: 'eu'})).toBe(
-    'https://assets.us-east-1.saucelabs.com'
-  );
   expect(getAssetHost({region: 'staging'})).toBe(
     'https://assets.staging.saucelabs.net'
   );
@@ -110,13 +92,12 @@ test('toString', () => {
     toString({
       username: 'foobar',
       _accessKey: '50fc1a11-3231-4240-9707-8f34682b17b0',
-      _options: {region: 'us', headless: false},
+      _options: {region: 'us'},
     })
   ).toBe(`SauceLabs API Client {
   username: 'foobar',
   key: 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXX2b17b0',
   region: 'us',
-  headless: false,
   proxy: undefined
 }`);
 });


### PR DESCRIPTION
# One-line summary

> Issue : #245

## Description

**This is a breaking change**

Removing the `--headless` option that was mapped to the `us-east-1` datacenter.

```
      --headless  if set to true you are accessing the headless Sauce instances
                  (this discards the `region` option) [boolean] [default: false]
```

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)
- Configuration change

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
These should highlight any db migrations, feature toggles, etc.
