### PR TITLE
resolves #244

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Your Sauce Labs datacenter region. The following regions are available:
 
 - `us-west-1` (short `us`)
 - `eu-central-1` (short `eu`)
+- `us-east-4` (real mobile devices only)
 
 Type: `string`
 Default: `us`

--- a/apis/builds.json
+++ b/apis/builds.json
@@ -13,7 +13,7 @@
         "region": {
           "default": "us-west-1",
           "description": "region of datacenter",
-          "enum": ["us-west-1", "us-east-1", "eu-central-1", "staging"]
+          "enum": ["us-west-1", "us-east-4", "eu-central-1", "staging"]
         },
         "tld": {
           "default": "com",

--- a/apis/sauce.json
+++ b/apis/sauce.json
@@ -24,7 +24,7 @@
         "region": {
           "default": "us-west-1",
           "description": "region of datacenter",
-          "enum": ["us-west-1", "us-east-1", "eu-central-1", "staging"]
+          "enum": ["us-west-1", "us-east-4", "eu-central-1", "staging"]
         },
         "tld": {
           "default": "com",

--- a/apis/teamManagement.json
+++ b/apis/teamManagement.json
@@ -13,7 +13,7 @@
         "region": {
           "default": "us-west-1",
           "description": "region of datacenter",
-          "enum": ["us-west-1", "us-east-1", "eu-central-1", "staging"]
+          "enum": ["us-west-1", "us-east-4", "eu-central-1", "staging"]
         },
         "tld": {
           "default": "com",

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -25,7 +25,7 @@ export interface SauceLabsOptions {
      *
      * - us-west-1 (short 'us')
      * - eu-central-1 (short 'eu')
-     * - us-east-1
+     * - us-east-4
      */
     region?: ${regions};
     /**

--- a/src/constants.js
+++ b/src/constants.js
@@ -96,7 +96,7 @@ export const ASSET_REGION_MAPPING = {
   us: '',
   eu: 'eu-central-1.',
   'us-west-1': '',
-  'us-east-1': 'us-east-1.',
+  'us-east-4': 'us-east-4.',
   'eu-central-1': 'eu-central-1.',
   staging: 'staging.',
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -85,7 +85,7 @@ export function getAPIHost(servers, basePath, options) {
  * helper to generate host for assets, like:
  * https://assets.saucelabs.com/jobs/<jobId>/selenium-server.log
  * https://assets.eu-central-1.saucelabs.com/jobs/<jobId>/log.json
- * https://assets.us-east-1.saucelabs.com/jobs/<jobId>/log.json
+ * https://assets.us-east-4.saucelabs.com/jobs/<jobId>/log.json
  * https://assets.staging.saucelabs.net/jobs/<jobId>/log.json
  */
 export function getAssetHost(options) {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -81,10 +81,10 @@ test('should expose a webdriverEndpoint', () => {
   const api3 = new SauceLabs({
     user: 'foo',
     key: 'bar',
-    region: 'us-east-1',
+    region: 'us-east-4',
   });
   expect(api3.webdriverEndpoint).toBe(
-    'https://ondemand.us-east-1.saucelabs.com/'
+    'https://ondemand.us-east-4.saucelabs.com/'
   );
 
   const api4 = new SauceLabs({user: 'foo', key: 'bar', region: 'us-central-3'});

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -40,8 +40,8 @@ test('getAPIHost', () => {
     getAPIHost(sauceAPI.servers, sauceAPI.basePath, {region: 'us-west-1'})
   ).toBe('https://api.us-west-1.saucelabs.com/rest');
   expect(
-    getAPIHost(sauceAPI.servers, sauceAPI.basePath, {region: 'us-east-1'})
-  ).toBe('https://api.us-east-1.saucelabs.com/rest');
+    getAPIHost(sauceAPI.servers, sauceAPI.basePath, {region: 'us-east-4'})
+  ).toBe('https://api.us-east-4.saucelabs.com/rest');
   expect(
     getAPIHost(sauceAPI.servers, sauceAPI.basePath, {host: 'http://foobar.com'})
   ).toBe('http://foobar.com/rest');
@@ -78,6 +78,9 @@ test('getAssetHost', () => {
   );
   expect(getAssetHost({region: 'eu-central-1'})).toBe(
     'https://assets.eu-central-1.saucelabs.com'
+  );
+  expect(getAssetHost({region: 'us-east-4'})).toBe(
+    'https://assets.us-east-4.saucelabs.com'
   );
   expect(getAssetHost({region: 'staging'})).toBe(
     'https://assets.staging.saucelabs.net'


### PR DESCRIPTION
# One-line summary

> Issue : #244

`s/us-east-1/us-east-4/g`

## Description

Some time ago Sauce Labs EOLed the us-east-1 region and and added new one - us-east-4. `us-east-4` region hosts real mobile devices only so some of the APIs are not supported there.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Configuration change

## Review
_List of tasks the reviewer must do to review the PR_
- [x] Tests
- [x] Documentation
- [ ] CHANGELOG
