### PR TITLE
Resolves #262

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Node Sauce Labs [![Test Changes](https://github.com/saucelabs/node-saucelabs/actions/workflows/test.yml/badge.svg)](https://github.com/saucelabs/node-saucelabs/actions/workflows/test.yml)
 
-Wrapper around all Sauce Labs REST APIs for [Node.js](http://nodejs.org/) (v14 or higher) including support for
+Wrapper around all Sauce Labs REST APIs for [Node.js](http://nodejs.org/) (v18 or higher) including support for
 [Sauce Connect Proxy](https://docs.saucelabs.com/secure-connections/sauce-connect/) and TypeScript definitions.
 
 ## Install


### PR DESCRIPTION
# One-line summary

> Issue : #262

- Adding tests for node v20,22
- Removing tests/support for node v14,16

## Description

- v16 support ended on 11 Sep 2023
- v18 support ends on 30 Apr 2025