### PR TITLE
Re-introduce support for node.js 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
     steps:
       - name: Clone Repository
         uses: actions/checkout@v4

--- a/src/sauceConnectHealthcheck.js
+++ b/src/sauceConnectHealthcheck.js
@@ -1,12 +1,28 @@
+import http from 'http';
 import {SC_HEALTHCHECK_TIMEOUT} from './constants';
 
 export default class SauceConnectHealthCheck {
   async perform(apiAddress) {
-    const response = await fetch(`${apiAddress}/readyz`, {
-      signal: AbortSignal.timeout(SC_HEALTHCHECK_TIMEOUT),
+    return new Promise((resolve, reject) => {
+      const request = http.get(
+        `${apiAddress}/readyz`,
+        {timeout: SC_HEALTHCHECK_TIMEOUT},
+        (response) => {
+          if (response.statusCode !== 200) {
+            reject(
+              new Error(`response status code ${response.statusCode} != 200`)
+            );
+          } else {
+            resolve();
+          }
+        }
+      );
+
+      request.on('error', reject);
+      request.on('timeout', () => {
+        request.destroy();
+        reject(new Error('Request timed out'));
+      });
     });
-    if (response.status !== 200) {
-      throw new TypeError(`response status code ${response.status} != 200`);
-    }
   }
 }


### PR DESCRIPTION
## Description
With the introduction of SC5 (https://github.com/saucelabs/node-saucelabs/pull/265), the fetch module was used for making HTTP requests. Since this module is supported from Node.js 18.x onward, we unintentionally dropped support for Node.js 16.x.

This PR replaces fetch with the http module to restore compatibility. 

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)