### PR TITLE
Fix flaky sauceConnectLoader _download tests hitting real network

### DIFF
--- a/tests/sauceConnectLoader.test.js
+++ b/tests/sauceConnectLoader.test.js
@@ -106,7 +106,14 @@ describe('SauceConnectLoader', () => {
           .spyOn(fs.promises, 'rename')
           .mockImplementation(() => Promise.resolve());
         scl = new SauceConnectLoader('1.2.3');
-        mockHttpsGet = jest.spyOn(https, 'get');
+        mockHttpsGet = jest
+          .spyOn(https, 'get')
+          .mockImplementation((url, callback) => {
+            // fake response: pipe finishes the write stream without
+            // touching the network
+            callback({pipe: (destStream) => destStream.end()});
+            return {on: jest.fn()};
+          });
 
         mockCompressingLinux = jest
           .spyOn(compressing.tgz, 'uncompress')


### PR DESCRIPTION
## Summary
- `tests/sauceConnectLoader.test.js`'s `_download()` tests spied on `https.get` but never gave it a `mockImplementation`, unlike the sibling `compressing.tgz`/`compressing.zip` mocks in the same `beforeEach`. As a result, the linux/macos/windows `_download()` tests made a real network request to `httpbin.org` on every run.
- Under load this occasionally exceeded Jest's 5000ms default test timeout, causing intermittent failures unrelated to any actual code change — reproduced this locally on `main` before touching anything, and it also hit `test (18.x)` in #306's first-ever CI run on this repo.
- Fix: stub the response the same way the compressing mocks already are — `pipe()` ends the write stream immediately, so `_download()` resolves without touching the network.

## Why
Discovered while investigating a red check on #306 (unrelated dependency-bump PR). Root cause isolated to this pre-existing test gap, not the dependency bumps.

## Test plan
- [x] `npm run build`
- [x] `npm run test:lint`
- [x] `npm run test:unit` — 82/82 pass, `sauceConnectLoader.js` coverage 93.1% → 100%
- [x] Ran the affected test file 10x back-to-back locally to confirm the flake is gone (each run ~0.3s, down from ~1-2s of real network I/O)

🤖 Generated with [Claude Code](https://claude.com/claude-code)