### PR TITLE
Restrict published npm package to runtime files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo
+* @saucelabs/devx

--- a/package.json
+++ b/package.json
@@ -14,6 +14,12 @@
     "sl": "./bin/sl"
   },
   "typings": "./build/index.d.ts",
+  "files": [
+    "apis",
+    "bin",
+    "build",
+    "!build/sc-loader"
+  ],
   "scripts": {
     "build": "run-s clean compile generate:typings",
     "clean": "rm -rf ./build ./coverage",


### PR DESCRIPTION
## What

Adds a `files` allowlist to `package.json` so the published npm package contains only what's needed at runtime (`build/`, `bin/`, `apis/`, plus README/LICENSE), and adds a CODEOWNERS file routing reviews to `@saucelabs/devx`.

## Why

The published `saucelabs@9.0.2` tarball accidentally shipped files swept in from the publish workflow's working directory — most notably a **15 MB Sauce Connect 5.2.2 Linux binary** (`sc-loader/sauce-connect-5.2.2_linux.x86_64.tar.gz`) that the e2e tests had downloaded during CI, along with repo housekeeping files (`.github/`, `.husky/`, `e2e/`, `docs/`, dotfiles). None of these are used at runtime — Sauce Connect is downloaded on demand by `SauceConnectLoader`.

Shipping a stale Sauce Connect binary is a real problem for consumers: security scanners flag the package for vulnerabilities in the old bundled binary (it was built with Go 1.23.2, which is affected by known Go stdlib CVEs fixed in later releases), even though the binary is never executed from there.

The allowlist includes an explicit `!build/sc-loader` exclusion so a leftover Sauce Connect download can never be packed again, even when publishing from a workspace where the e2e tests have run.

## Result

- Package size: **15.2 MB → 91 kB** (36 → 21 files)
- `npm pack` verified: all runtime files present (`bin/sl` → `build/cli`, `build/constants.js` → `apis/*.json`), no binaries, no housekeeping files
- Verified the guard: with a planted `build/sc-loader/sauce-connect-*.tar.gz`, `npm pack --dry-run` still excludes it
- `npm run test:lint` and `npm run test:unit` (82/82) pass

Note: for CODEOWNERS review-routing to take effect, the `devX` team needs read access to this repo (currently no team is attached — only individual collaborators).

🤖 Generated with [Claude Code](https://claude.com/claude-code)