### PR TITLE
Fix npm publish workflow for Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -37,6 +37,9 @@ jobs:
   release:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Clone Repository
         uses: actions/checkout@v3
@@ -45,6 +48,8 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
+      - name: Update npm to a version that supports Trusted Publishing
+        run: npm install -g npm@latest
       - name: Setup Git
         run: |
           git config --global user.name "oss-sauce-bot"


### PR DESCRIPTION
# Fix npm publish workflow for Trusted Publishing (OIDC)

> Issue : #1234 (only if appropriate)

## Description
The manual "Manual NPM Publish" workflow started failing (run: https://github.com/saucelabs/node-saucelabs/actions/runs/30078435200/job/89434473115) with `npm error code E404` right after npm Trusted Publishing was enabled for this package on npmjs.com. The workflow was still authenticating with the classic `NPM_TOKEN`/`NODE_AUTH_TOKEN` and never requested an OIDC token, so it couldn't use Trusted Publishing and the registry rejected the publish. This PR adds the `id-token: write` permission and upgrades npm to a version that supports the OIDC exchange.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Configuration change

## Tasks
_List of tasks you will do to complete the PR_
  - [x] Add `permissions: id-token: write` (and `contents: write`) to the `release` job
  - [x] Add a step to upgrade npm to >= 11.5.1 (Node 22 bundles npm 10.9.8, which doesn't support Trusted Publishing)

## Review
_List of tasks the reviewer must do to review the PR_
- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
No db migrations or feature toggles. Recommend keeping the `NPM_TOKEN` secret as a fallback for one release run to confirm OIDC publishing succeeds, then remove it as a follow-up cleanup once confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)