### PR TITLE
Fix missing trailing commas in sauceConnectManager.test.js

### DIFF
--- a/tests/sauceConnectManager.test.js
+++ b/tests/sauceConnectManager.test.js
@@ -15,7 +15,7 @@ describe('SauceConnectManager', () => {
       });
       const error = await manager.waitForReady(':8042').catch((err) => err);
       expect(error.message).toBe(
-        'Sauce Connect exited before reaching a ready state'
+        'Sauce Connect exited before reaching a ready state',
       );
     });
 
@@ -44,7 +44,7 @@ describe('SauceConnectManager', () => {
             async perform() {
               throw new Error('custom error');
             },
-          }
+          },
         );
         const error = await manager.waitForReady(':8042').catch((err) => err);
         expect(error.message).toBe('custom error');


### PR DESCRIPTION
# Fix missing trailing commas in sauceConnectManager.test.js

## Description
While investigating the Jest 30 upgrade in #322, `npx prettier --check` surfaced a pre-existing formatting drift in `tests/sauceConnectManager.test.js`: two call sites were missing a trailing comma that Prettier expects. This is a cosmetic-only fix with no behavior change.

## Types of Changes
- Refactor/improvements

## Tasks
- [x] Added trailing comma after the `toBe(...)` argument in the "process terminated with exitCode" test
- [x] Added trailing comma after the `SauceConnectManager` constructor's last argument in the "error when requesting healthcheck" test

## Review
- [x] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
None — test-only formatting change, no runtime code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLYQi8He2kGF9VRSMvs71q