### PR TITLE
Increase Sauce Connect ready timeout to reduce Windows E2E flakiness

### DIFF
--- a/e2e/sc.test.js
+++ b/e2e/sc.test.js
@@ -5,7 +5,7 @@ const ID = process.env.GITHUB_RUN_ID ?? '(local)';
 // in GitHub Actions, otherwise it fails for untrusted PRs
 const SKIP_TEST = process.env.GITHUB_RUN_ID && !process.env.SAUCE_USERNAME;
 
-jest.setTimeout(120 * 1000); // 120s should be sufficient to run all SC tests
+jest.setTimeout(150 * 1000); // 150s to allow for the 120s SC ready timeout plus close overhead
 
 /**
  * unmock
@@ -45,7 +45,7 @@ test('should not be able to run Sauce Connect due to invalid credentials', async
     })
     .catch((err) => err);
   expect(err.message).toContain(
-    'Sauce Connect exited before reaching a ready state'
+    'Sauce Connect exited before reaching a ready state',
   );
 });
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -127,7 +127,7 @@ export const CLI_PARAMS = [
 ];
 const CLI_PARAM_KEYS = CLI_PARAMS.map((param) => param.name);
 const CLI_PARAM_ALIASES = CLI_PARAMS.map((param) => param.alias).filter(
-  Boolean
+  Boolean,
 );
 
 export const SAUCE_CONNECT_CLI_PARAMS = [
@@ -314,14 +314,14 @@ export const SAUCE_CONNECT_CLI_PARAMS = [
   },
 ];
 export const SC_BOOLEAN_CLI_PARAMS = SAUCE_CONNECT_CLI_PARAMS.filter(
-  (p) => p.type === 'boolean'
+  (p) => p.type === 'boolean',
 ).map((p) => p.name);
 
 const SAUCE_CONNECT_CLI_PARAM_ALIASES = SAUCE_CONNECT_CLI_PARAMS.map(
-  (param) => param.alias
+  (param) => param.alias,
 ).filter(Boolean);
 export const SC_CLI_PARAM_KEYS = SAUCE_CONNECT_CLI_PARAMS.map(
-  (param) => param.name
+  (param) => param.name,
 );
 export const SC_PARAMS_TO_STRIP = [
   ...CLI_PARAM_KEYS,
@@ -330,5 +330,5 @@ export const SC_PARAMS_TO_STRIP = [
 ];
 
 export const SC_CLOSE_TIMEOUT = 10000;
-export const SC_READY_TIMEOUT = 60000;
+export const SC_READY_TIMEOUT = 120000;
 export const SC_HEALTHCHECK_TIMEOUT = 1000;


### PR DESCRIPTION
# Increase Sauce Connect ready timeout to reduce Windows E2E flakiness

## Description
The e2e job (`e2e/sc.test.js`) intermittently fails on the Windows leg of the CI test matrix while waiting for Sauce Connect to become ready. `SC_READY_TIMEOUT` in `src/constants.js` is a fixed 60s window before `SauceConnectManager.waitForReady` gives up on the `/readyz` healthcheck; Windows runners likely take longer to spawn the process and pass AV/Defender scanning, making 60s too tight there. This PR bumps `SC_READY_TIMEOUT` to 120s (applies to all platforms, not just CI) and increases the e2e suite's Jest timeout from 120s to 150s so a single test has headroom for the new ready timeout plus `close()` overhead.

## Types of Changes
- Bug fix (non-breaking change which fixes an issue)
- Configuration change

## Tasks
  - [x] Bump `SC_READY_TIMEOUT` from 60s to 120s in `src/constants.js`
  - [x] Increase `e2e/sc.test.js` Jest timeout to match

## Review
- [x] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
No db migrations or feature toggles. This only widens a client-side timeout, so it is backwards compatible; no action needed by consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLYQi8He2kGF9VRSMvs71q